### PR TITLE
feat: Add conditional text field for question 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bro-frontend",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@10.29.2",
+  "packageManager": "pnpm@10.32.0",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.3.14",
     "@tailwindcss/postcss": "^4.1.18",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.1.18
         version: 4.1.18
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/node':
         specifier: ^24.10.1
         version: 24.10.13
@@ -108,6 +111,18 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.28.6':
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
 
   '@biomejs/biome@2.3.14':
     resolution: {integrity: sha512-QMT6QviX0WqXJCaiqVMiBUCr5WRQ1iFSjvOLoTk6auKukJMvnMzWucXpwZB0e8F00/1/BsS9DzcKgWH+CLqVuA==}
@@ -956,6 +971,28 @@ packages:
   '@tanstack/store@0.8.1':
     resolution: {integrity: sha512-PtOisLjUZPz5VyPRSCGjNOlwTvabdTBQ2K80DpVL1chGVr35WRxfeavAPdNq6pm/t7F8GhoR2qtmkkqtCEtHYw==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1012,6 +1049,17 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1083,9 +1131,16 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -1200,6 +1255,9 @@ packages:
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
     engines: {node: '>=14'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   jsdom@28.1.0:
     resolution: {integrity: sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==}
@@ -1342,6 +1400,10 @@ packages:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
     engines: {node: 20 || >=22}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1431,6 +1493,10 @@ packages:
     resolution: {integrity: sha512-QCYG84SgGyGzqJ/vlMsxeXd/pgL/I94ixdNFyh1PusWmTCyVfPJjZ1K1jvHtsbfnXQs2TSkEP2fR7QiMZAnKFQ==}
     engines: {node: '>= 0.6'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
@@ -1458,6 +1524,9 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-property@2.0.2:
     resolution: {integrity: sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==}
@@ -1770,6 +1839,16 @@ snapshots:
       lru-cache: 11.2.6
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/runtime@7.28.6': {}
 
   '@biomejs/biome@2.3.14':
     optionalDependencies:
@@ -2328,6 +2407,29 @@ snapshots:
 
   '@tanstack/store@0.8.1': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.28.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -2393,6 +2495,14 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
   assertion-error@2.0.1: {}
 
   atomic-sleep@1.0.0: {}
@@ -2449,7 +2559,11 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -2588,6 +2702,8 @@ snapshots:
 
   js-cookie@3.0.5: {}
 
+  js-tokens@4.0.0: {}
+
   jsdom@28.1.0:
     dependencies:
       '@acemir/cssom': 0.9.31
@@ -2709,6 +2825,8 @@ snapshots:
 
   lru-cache@11.2.6: {}
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2812,6 +2930,12 @@ snapshots:
   precond@0.2.3:
     optional: true
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   process-warning@5.0.0: {}
 
   prom-client@15.1.3:
@@ -2840,6 +2964,8 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react-property@2.0.2: {}
 

--- a/src/components/form-components/RadioGroup.tsx
+++ b/src/components/form-components/RadioGroup.tsx
@@ -6,6 +6,7 @@ type RadioOption = {
   id: string;
   label: string;
 };
+
 export type RadioGroupQuestion = {
   type: "RADIO_GROUP";
   label: string;

--- a/src/components/form-components/TextArea.tsx
+++ b/src/components/form-components/TextArea.tsx
@@ -4,7 +4,7 @@ import { useFieldContext } from "@/hooks/form";
 
 export type TextQuestion = {
   label: string;
-  description?: string;
+  description: string | null;
   type: "TEXT";
 };
 

--- a/src/features/kartleggingssporsmal/form/KartleggingssporsmalForm.tsx
+++ b/src/features/kartleggingssporsmal/form/KartleggingssporsmalForm.tsx
@@ -7,7 +7,6 @@ import { useState } from "react";
 import { logTaxonomyEvent } from "@/analytics/logTaxonomyEvent";
 import {
   fieldIdsDisplayOrder,
-  kartleggingssporsmalFormDefaults,
   kartleggingssporsmalFormQuestions,
   kartleggingssporsmalFormSchema,
   shouldIncludeTilbakeTilJobbBegrunnelseField,
@@ -15,6 +14,7 @@ import {
 import { useAppForm } from "@/hooks/form";
 import { submitFormAction } from "@/services/meroppfolging/actions/submitFormAction";
 import type { KartleggingssporsmalFormResponse } from "@/services/meroppfolging/schemas/formSnapshotSchema";
+import { formDefaultValues } from "./formDefaultValues";
 
 type Props = {
   setSummaryItems: (data: KartleggingssporsmalFormResponse) => void;
@@ -34,7 +34,7 @@ export default function KartleggingssporsmalForm({ setSummaryItems }: Props) {
   const [submitError, setSubmitError] = useState<boolean>(false);
 
   const form = useAppForm({
-    defaultValues: kartleggingssporsmalFormDefaults,
+    defaultValues: formDefaultValues,
     validationLogic: revalidateLogic(),
     validators: {
       onDynamic: kartleggingssporsmalFormSchema,

--- a/src/features/kartleggingssporsmal/form/KartleggingssporsmalForm.tsx
+++ b/src/features/kartleggingssporsmal/form/KartleggingssporsmalForm.tsx
@@ -6,9 +6,11 @@ import { revalidateLogic } from "@tanstack/form-core";
 import { useState } from "react";
 import { logTaxonomyEvent } from "@/analytics/logTaxonomyEvent";
 import {
+  fieldIdsDisplayOrder,
   kartleggingssporsmalFormDefaults,
   kartleggingssporsmalFormQuestions,
   kartleggingssporsmalFormSchema,
+  shouldIncludeTilbakeTilJobbBegrunnelseField,
 } from "@/forms/kartleggingssporsmalForm";
 import { useAppForm } from "@/hooks/form";
 import { submitFormAction } from "@/services/meroppfolging/actions/submitFormAction";
@@ -79,33 +81,39 @@ export default function KartleggingssporsmalForm({ setSummaryItems }: Props) {
     >
       <form.AppForm>
         <div className="grid gap-4 mb-4">
-          <form.AppField name="hvorSannsynligTilbakeTilJobben">
-            {(field) => (
-              <field.RadioGroup
-                question={
-                  kartleggingssporsmalFormQuestions.hvorSannsynligTilbakeTilJobben
+          <form.Subscribe
+            selector={(state) => state.values.hvorSannsynligTilbakeTilJobben}
+          >
+            {(hvorSannsynligTilbakeTilJobben) => {
+              const includeJobbBegrunnelseField =
+                shouldIncludeTilbakeTilJobbBegrunnelseField(
+                  hvorSannsynligTilbakeTilJobben,
+                );
+
+              return fieldIdsDisplayOrder.map((fieldId) => {
+                if (
+                  fieldId === "hvorSannsynligTilbakeTilJobbenBegrunnelse" &&
+                  !includeJobbBegrunnelseField
+                ) {
+                  return null;
                 }
-              />
-            )}
-          </form.AppField>
-          <form.AppField name="samarbeidOgRelasjonTilArbeidsgiver">
-            {(field) => (
-              <field.RadioGroup
-                question={
-                  kartleggingssporsmalFormQuestions.samarbeidOgRelasjonTilArbeidsgiver
-                }
-              />
-            )}
-          </form.AppField>
-          <form.AppField name="naarTilbakeTilJobben">
-            {(field) => (
-              <field.RadioGroup
-                question={
-                  kartleggingssporsmalFormQuestions.naarTilbakeTilJobben
-                }
-              />
-            )}
-          </form.AppField>
+
+                const question = kartleggingssporsmalFormQuestions[fieldId];
+
+                return (
+                  <form.AppField key={fieldId} name={fieldId}>
+                    {(field) =>
+                      question.type === "RADIO_GROUP" ? (
+                        <field.RadioGroup question={question} />
+                      ) : (
+                        <field.TextArea question={question} />
+                      )
+                    }
+                  </form.AppField>
+                );
+              });
+            }}
+          </form.Subscribe>
         </div>
 
         {submitError && (

--- a/src/features/kartleggingssporsmal/form/formDefaultValues.ts
+++ b/src/features/kartleggingssporsmal/form/formDefaultValues.ts
@@ -1,0 +1,12 @@
+import type { KartleggingssporsmalForm } from "@/forms/kartleggingssporsmalForm";
+
+type KartleggingssporsmalFormAlsoUnfilled = {
+  [K in keyof KartleggingssporsmalForm]: KartleggingssporsmalForm[K] | "";
+};
+
+export const formDefaultValues: KartleggingssporsmalFormAlsoUnfilled = {
+  hvorSannsynligTilbakeTilJobben: "",
+  hvorSannsynligTilbakeTilJobbenBegrunnelse: "",
+  samarbeidOgRelasjonTilArbeidsgiver: "",
+  naarTilbakeTilJobben: "",
+};

--- a/src/features/kartleggingssporsmal/summary/KartleggingssporsmalFormSummary.test.tsx
+++ b/src/features/kartleggingssporsmal/summary/KartleggingssporsmalFormSummary.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, it } from "vitest";
+import { fieldSnapshotsFixture } from "@/mocks/fixture/form";
+import KartleggingssporsmalFormSummary from "./KartleggingssporsmalFormSummary";
+
+const formSnapshotFixture = {
+  formIdentifier: "kartleggingssporsmal",
+  formSemanticVersion: "1.0.0",
+  formSnapshotVersion: "1.0.0",
+  fieldSnapshots: fieldSnapshotsFixture,
+};
+
+describe("KartleggingssporsmalFormSummary", () => {
+  it("renders labels and selected answers for all fields", () => {
+    render(
+      <KartleggingssporsmalFormSummary formSnapshot={formSnapshotFixture} />,
+    );
+
+    screen.getByText(
+      "Hvor sannsynlig er det at du kommer tilbake i jobben du ble sykmeldt fra?",
+    );
+    screen.getByText("Jeg tror det er veldig sannsynlig");
+
+    screen.getByText(
+      "Hvordan vil du beskrive samarbeidet og relasjonen mellom deg og arbeidsgiveren din?",
+    );
+    screen.getByText("Jeg opplever forholdet vårt som godt");
+
+    screen.getByText("Hvor lenge tror du at du har behov for å være sykmeldt?");
+    screen.getByText("Mindre enn 26 uker (6 måneder) totalt");
+  });
+
+  it("renders 'Ingen tekst' for an empty TEXT field", () => {
+    render(
+      <KartleggingssporsmalFormSummary
+        formSnapshot={{
+          ...formSnapshotFixture,
+          fieldSnapshots: [
+            {
+              fieldId: "hvorSannsynligTilbakeTilJobbenBegrunnelse",
+              label: "Utdyp svaret ditt",
+              description: null,
+              fieldType: "TEXT",
+              value: "",
+            },
+          ],
+        }}
+      />,
+    );
+
+    screen.getByText("Utdyp svaret ditt");
+    screen.getByText("Ingen tekst");
+  });
+});

--- a/src/features/kartleggingssporsmal/summary/KartleggingssporsmalFormSummary.tsx
+++ b/src/features/kartleggingssporsmal/summary/KartleggingssporsmalFormSummary.tsx
@@ -7,31 +7,76 @@ import {
   FormSummaryLabel,
   FormSummaryValue,
 } from "@navikt/ds-react/FormSummary";
-
-export type FormSummaryItem = {
-  id: string;
-  label: string;
-  value: string;
-};
+import type { FormSnapshot } from "@/services/meroppfolging/schemas/formSnapshotSchema";
 
 type Props = {
-  items: FormSummaryItem[];
+  formSnapshot: FormSnapshot;
 };
 
-export default function KartleggingssporsmalFormSummary({ items }: Props) {
+export default function KartleggingssporsmalFormSummary({
+  formSnapshot,
+}: Props) {
+  const items = mapFormSnapshotToSummaryItems(formSnapshot);
+
   return (
     <AkselFormSummary>
       <FormSummaryHeader>
         <FormSummaryHeading level="2">Dette svarte du</FormSummaryHeading>
       </FormSummaryHeader>
       <FormSummaryAnswers>
-        {items.map((it) => (
-          <FormSummaryAnswer key={it.id}>
-            <FormSummaryLabel>{it.label}</FormSummaryLabel>
-            <FormSummaryValue>{it.value}</FormSummaryValue>
+        {items.map((item) => (
+          <FormSummaryAnswer key={item.id}>
+            <FormSummaryLabel>{item.label}</FormSummaryLabel>
+            <FormSummaryValue>
+              {item.type === "TEXT" && item.value === "" ? (
+                <em>Ingen tekst</em>
+              ) : (
+                item.value
+              )}
+            </FormSummaryValue>
           </FormSummaryAnswer>
         ))}
       </FormSummaryAnswers>
     </AkselFormSummary>
   );
+}
+
+type FormSummaryItem = {
+  id: string;
+  label: string;
+  value: string;
+  type: "TEXT" | "RADIO_GROUP";
+};
+
+function mapFormSnapshotToSummaryItems(
+  formSnapshot: FormSnapshot,
+): FormSummaryItem[] {
+  return formSnapshot.fieldSnapshots.map((field) => {
+    switch (field.fieldType) {
+      case "RADIO_GROUP": {
+        const selectedOption = field.options.find(
+          (option) => option.wasSelected,
+        );
+        return {
+          id: field.fieldId,
+          label: field.label,
+          value: selectedOption?.optionLabel || "",
+          type: "RADIO_GROUP",
+        };
+      }
+      case "TEXT":
+        return {
+          id: field.fieldId,
+          label: field.label,
+          value: field.value,
+          type: "TEXT",
+        };
+      // Missing 'fieldType' causes a compile-time error if we use the following check:
+      // https://gibbok.github.io/typescript-book/book/exhaustiveness-checking/
+      default: {
+        const _exhaustiveCheck: never = field;
+        return _exhaustiveCheck;
+      }
+    }
+  });
 }

--- a/src/features/kartleggingssporsmal/summary/KartleggingssporsmalFormSummaryPage.tsx
+++ b/src/features/kartleggingssporsmal/summary/KartleggingssporsmalFormSummaryPage.tsx
@@ -5,7 +5,6 @@ import { CONTACT_NAV_URL } from "@/constants";
 import ThankYouAlert from "@/features/kartleggingssporsmal/summary/ThankYouAlert";
 import { UsefulLinks } from "@/features/kartleggingssporsmal/summary/UsefulLinks";
 import type { KartleggingssporsmalFormResponse } from "@/services/meroppfolging/schemas/formSnapshotSchema";
-import { mapFormSnapshotToSummaryItems } from "@/utils/kartleggingssporsmalForm";
 import KartleggingssporsmalFormSummary from "./KartleggingssporsmalFormSummary";
 
 type Props = {
@@ -13,19 +12,15 @@ type Props = {
 };
 
 export default function KartleggingssporsmalFormSummaryPage({
-  formResponse,
+  formResponse: { formSnapshot, createdAt },
 }: Props) {
-  const summaryItems = mapFormSnapshotToSummaryItems(
-    formResponse.formSnapshot.fieldSnapshots,
-  );
-
   return (
     <VStack gap="space-24">
       <Heading size={"large"} level="1">
         Kartlegging av din situasjon
       </Heading>
 
-      <ThankYouAlert date={formResponse.createdAt} />
+      <ThankYouAlert date={createdAt} />
 
       <BodyShort className="" spacing>
         Svarene dine gir Nav innsikt i hvordan vi skal følge deg opp fremover.
@@ -33,7 +28,7 @@ export default function KartleggingssporsmalFormSummaryPage({
         gi deg, vil du bli kontaktet av en Nav-veileder.
       </BodyShort>
 
-      <KartleggingssporsmalFormSummary items={summaryItems} />
+      <KartleggingssporsmalFormSummary formSnapshot={formSnapshot} />
 
       <UsefulLinks />
 

--- a/src/forms/kartleggingssporsmalForm.ts
+++ b/src/forms/kartleggingssporsmalForm.ts
@@ -1,7 +1,8 @@
 import { type ZodType, z } from "zod/v4";
 import type { RadioGroupQuestion } from "@/components/form-components/RadioGroup";
+import type { TextQuestion } from "@/components/form-components/TextArea";
 
-export const kartleggingssporsmalFormQuestions = {
+const radioGroupQuestions = {
   hvorSannsynligTilbakeTilJobben: {
     type: "RADIO_GROUP",
     label:
@@ -34,36 +35,75 @@ export const kartleggingssporsmalFormQuestions = {
   },
 } as const satisfies Record<string, RadioGroupQuestion>;
 
-type KartleggingsspormalFormQuestionId =
+const textQuestions = {
+  hvorSannsynligTilbakeTilJobbenBegrunnelse: {
+    type: "TEXT",
+    label:
+      "Hvis du ønsker det kan du her utdype svaret ditt på forrige spørmsål. Det er valgfritt.",
+    description: "Svaret blir ikke delt med arbeidsgiveren din.",
+  },
+} as const satisfies Record<string, TextQuestion>;
+
+export const kartleggingssporsmalFormQuestions = {
+  ...radioGroupQuestions,
+  ...textQuestions,
+} as const;
+
+export type KartleggingsspormalFormQuestionId =
   keyof typeof kartleggingssporsmalFormQuestions;
 
-function getOptionIds<T extends KartleggingsspormalFormQuestionId>(
-  fieldId: T,
-): (typeof kartleggingssporsmalFormQuestions)[T]["options"][number]["id"][] {
-  const question = kartleggingssporsmalFormQuestions[fieldId];
-  return question.options.map((option) => option.id);
+export const fieldIdsDisplayOrder: KartleggingsspormalFormQuestionId[] = [
+  "hvorSannsynligTilbakeTilJobben",
+  "hvorSannsynligTilbakeTilJobbenBegrunnelse",
+  "samarbeidOgRelasjonTilArbeidsgiver",
+  "naarTilbakeTilJobben",
+];
+
+function getRadioGroupOptionIds(
+  radioFieldId: keyof typeof radioGroupQuestions,
+) {
+  return radioGroupQuestions[radioFieldId].options.map((option) => option.id);
 }
 
 export const kartleggingssporsmalFormSchema = z.object({
   hvorSannsynligTilbakeTilJobben: z.enum(
-    getOptionIds("hvorSannsynligTilbakeTilJobben"),
+    getRadioGroupOptionIds("hvorSannsynligTilbakeTilJobben"),
     "Feltet er påkrevd",
   ),
+  hvorSannsynligTilbakeTilJobbenBegrunnelse: z.string(),
   samarbeidOgRelasjonTilArbeidsgiver: z.enum(
-    getOptionIds("samarbeidOgRelasjonTilArbeidsgiver"),
+    getRadioGroupOptionIds("samarbeidOgRelasjonTilArbeidsgiver"),
     "Feltet er påkrevd",
   ),
   naarTilbakeTilJobben: z.enum(
-    getOptionIds("naarTilbakeTilJobben"),
+    getRadioGroupOptionIds("naarTilbakeTilJobben"),
     "Feltet er påkrevd",
   ),
 } satisfies Record<KartleggingsspormalFormQuestionId, ZodType>);
+
 export type KartleggingssporsmalForm = z.infer<
   typeof kartleggingssporsmalFormSchema
 >;
 
-export const kartleggingssporsmalFormDefaults = {
-  hvorSannsynligTilbakeTilJobben: "",
-  samarbeidOgRelasjonTilArbeidsgiver: "",
-  naarTilbakeTilJobben: "",
+export function shouldIncludeTilbakeTilJobbBegrunnelseField(
+  hvorSannsynligTilbakeTilJobben:
+    | KartleggingssporsmalForm["hvorSannsynligTilbakeTilJobben"]
+    | "",
+): boolean {
+  return (
+    hvorSannsynligTilbakeTilJobben === "1b" ||
+    hvorSannsynligTilbakeTilJobben === "1c"
+  );
+}
+
+type KartleggingssporsmalFormAlsoUnfilled = {
+  [K in keyof KartleggingssporsmalForm]: KartleggingssporsmalForm[K] | "";
 };
+
+export const kartleggingssporsmalFormDefaults: KartleggingssporsmalFormAlsoUnfilled =
+  {
+    hvorSannsynligTilbakeTilJobben: "",
+    hvorSannsynligTilbakeTilJobbenBegrunnelse: "",
+    samarbeidOgRelasjonTilArbeidsgiver: "",
+    naarTilbakeTilJobben: "",
+  };

--- a/src/forms/kartleggingssporsmalForm.ts
+++ b/src/forms/kartleggingssporsmalForm.ts
@@ -2,6 +2,24 @@ import { type ZodType, z } from "zod/v4";
 import type { RadioGroupQuestion } from "@/components/form-components/RadioGroup";
 import type { TextQuestion } from "@/components/form-components/TextArea";
 
+export const fieldIdsDisplayOrder: KartleggingsspormalFormQuestionId[] = [
+  "hvorSannsynligTilbakeTilJobben",
+  "hvorSannsynligTilbakeTilJobbenBegrunnelse",
+  "samarbeidOgRelasjonTilArbeidsgiver",
+  "naarTilbakeTilJobben",
+];
+
+export function shouldIncludeTilbakeTilJobbBegrunnelseField(
+  hvorSannsynligTilbakeTilJobben:
+    | KartleggingssporsmalForm["hvorSannsynligTilbakeTilJobben"]
+    | "",
+): boolean {
+  return (
+    hvorSannsynligTilbakeTilJobben === "1b" ||
+    hvorSannsynligTilbakeTilJobben === "1c"
+  );
+}
+
 const radioGroupQuestions = {
   hvorSannsynligTilbakeTilJobben: {
     type: "RADIO_GROUP",
@@ -49,15 +67,8 @@ export const kartleggingssporsmalFormQuestions = {
   ...textQuestions,
 } as const;
 
-export type KartleggingsspormalFormQuestionId =
+type KartleggingsspormalFormQuestionId =
   keyof typeof kartleggingssporsmalFormQuestions;
-
-export const fieldIdsDisplayOrder: KartleggingsspormalFormQuestionId[] = [
-  "hvorSannsynligTilbakeTilJobben",
-  "hvorSannsynligTilbakeTilJobbenBegrunnelse",
-  "samarbeidOgRelasjonTilArbeidsgiver",
-  "naarTilbakeTilJobben",
-];
 
 function getRadioGroupOptionIds(
   radioFieldId: keyof typeof radioGroupQuestions,
@@ -84,26 +95,3 @@ export const kartleggingssporsmalFormSchema = z.object({
 export type KartleggingssporsmalForm = z.infer<
   typeof kartleggingssporsmalFormSchema
 >;
-
-export function shouldIncludeTilbakeTilJobbBegrunnelseField(
-  hvorSannsynligTilbakeTilJobben:
-    | KartleggingssporsmalForm["hvorSannsynligTilbakeTilJobben"]
-    | "",
-): boolean {
-  return (
-    hvorSannsynligTilbakeTilJobben === "1b" ||
-    hvorSannsynligTilbakeTilJobben === "1c"
-  );
-}
-
-type KartleggingssporsmalFormAlsoUnfilled = {
-  [K in keyof KartleggingssporsmalForm]: KartleggingssporsmalForm[K] | "";
-};
-
-export const kartleggingssporsmalFormDefaults: KartleggingssporsmalFormAlsoUnfilled =
-  {
-    hvorSannsynligTilbakeTilJobben: "",
-    hvorSannsynligTilbakeTilJobbenBegrunnelse: "",
-    samarbeidOgRelasjonTilArbeidsgiver: "",
-    naarTilbakeTilJobben: "",
-  };

--- a/src/forms/kartleggingssporsmalForm.ts
+++ b/src/forms/kartleggingssporsmalForm.ts
@@ -57,7 +57,7 @@ const textQuestions = {
   hvorSannsynligTilbakeTilJobbenBegrunnelse: {
     type: "TEXT",
     label:
-      "Hvis du ønsker det kan du her utdype svaret ditt på forrige spørmsål. Det er valgfritt.",
+      "Hvis du ønsker det kan du her utdype svaret ditt på forrige spørsmål. Det er valgfritt.",
     description: "Svaret blir ikke delt med arbeidsgiveren din.",
   },
 } as const satisfies Record<string, TextQuestion>;

--- a/src/mocks/fixture/form.ts
+++ b/src/mocks/fixture/form.ts
@@ -71,6 +71,24 @@ export const kartleggingssporsmalFormResponseFixture = {
 
 export const kartleggingssporsmalFormFixture: KartleggingssporsmalForm = {
   hvorSannsynligTilbakeTilJobben: "1a",
+  hvorSannsynligTilbakeTilJobbenBegrunnelse: "",
+  samarbeidOgRelasjonTilArbeidsgiver: "2a",
+  naarTilbakeTilJobben: "3a",
+};
+
+export const kartleggingssporsmalFormFixture2: KartleggingssporsmalForm = {
+  hvorSannsynligTilbakeTilJobben: "1b",
+  hvorSannsynligTilbakeTilJobbenBegrunnelse:
+    "Jeg tror det er lite sannsynlig fordi de ikke kan tilrettelegge for meg.",
+  samarbeidOgRelasjonTilArbeidsgiver: "2a",
+  naarTilbakeTilJobben: "3a",
+};
+
+// This kind of form value can happen if user selects "1b" or "1c" for first question, and then fills out the begrunnelse field, but then goes back and changes first answer to "1a". In this case, the begrunnelse field will disappear and should not be included in the snapshot.
+export const kartleggingssporsmalFormFixture3: KartleggingssporsmalForm = {
+  hvorSannsynligTilbakeTilJobben: "1a",
+  hvorSannsynligTilbakeTilJobbenBegrunnelse:
+    "Dette skal ikke inkluderes i snapshot siden første svar er 1a.",
   samarbeidOgRelasjonTilArbeidsgiver: "2a",
   naarTilbakeTilJobben: "3a",
 };

--- a/src/services/meroppfolging/actions/submitFormAction.ts
+++ b/src/services/meroppfolging/actions/submitFormAction.ts
@@ -28,11 +28,11 @@ export async function submitFormAction(
     );
   }
 
-  const fieldSnapshots = mapAppFormToSnapshot({ values: parsed.data });
+  const formSnapshot = mapAppFormToSnapshot({ values: parsed.data });
 
   if (isLocalOrDemo) {
     return {
-      formSnapshot: { fieldSnapshots: fieldSnapshots },
+      formSnapshot,
       createdAt: new Date(),
     };
   }
@@ -48,12 +48,7 @@ export async function submitFormAction(
   );
 
   const payload: FormSnapshotRequest = {
-    formSnapshot: {
-      formIdentifier: "kartleggingsporsmal",
-      formSemanticVersion: "1.0.0",
-      formSnapshotVersion: "1.0.0",
-      fieldSnapshots: fieldSnapshots,
-    },
+    formSnapshot,
   };
 
   try {

--- a/src/services/meroppfolging/schemas/formSnapshotSchema.ts
+++ b/src/services/meroppfolging/schemas/formSnapshotSchema.ts
@@ -31,18 +31,22 @@ export const fieldSnapshotsSchema = z.array(
 );
 export type FieldSnapshots = z.infer<typeof fieldSnapshotsSchema>;
 
+const formSnapshotSchema = z.object({
+  formIdentifier: z.string(),
+  formSemanticVersion: z.string(),
+  formSnapshotVersion: z.string(),
+  fieldSnapshots: fieldSnapshotsSchema,
+});
+
+export type FormSnapshot = z.infer<typeof formSnapshotSchema>;
+
 export const formSnapshotRequestSchema = z.object({
-  formSnapshot: z.object({
-    formIdentifier: z.string(),
-    formSemanticVersion: z.string(),
-    formSnapshotVersion: z.string(),
-    fieldSnapshots: fieldSnapshotsSchema,
-  }),
+  formSnapshot: formSnapshotSchema,
 });
 export type FormSnapshotRequest = z.infer<typeof formSnapshotRequestSchema>;
 
 const kartleggingssporsmalFormResponseSchema = z.object({
-  formSnapshot: z.object({ fieldSnapshots: fieldSnapshotsSchema }),
+  formSnapshot: formSnapshotSchema,
   createdAt: z.iso.datetime().transform((str) => new Date(str)),
 });
 export type KartleggingssporsmalFormResponse = z.infer<

--- a/src/utils/kartleggingssporsmalForm.test.ts
+++ b/src/utils/kartleggingssporsmalForm.test.ts
@@ -1,21 +1,19 @@
 import { describe, expect, it } from "vitest";
 import {
-  fieldSnapshotsFixture,
   kartleggingssporsmalFormFixture,
+  kartleggingssporsmalFormFixture2,
+  kartleggingssporsmalFormFixture3,
 } from "@/mocks/fixture/form";
-import {
-  mapAppFormToSnapshot,
-  mapFormSnapshotToSummaryItems,
-} from "@/utils/kartleggingssporsmalForm";
+import { mapAppFormToSnapshot } from "@/utils/kartleggingssporsmalForm";
 
 describe("kartleggingssporsmalForm utils", () => {
   describe("mapAppFormToSnapshot", () => {
     it("should map form values to fieldSnapshots", () => {
-      const snapshots = mapAppFormToSnapshot({
+      const formSnapshot = mapAppFormToSnapshot({
         values: kartleggingssporsmalFormFixture,
       });
 
-      expect(snapshots).toEqual([
+      expect(formSnapshot.fieldSnapshots).toEqual([
         {
           fieldId: "hvorSannsynligTilbakeTilJobben",
           label:
@@ -79,30 +77,97 @@ describe("kartleggingssporsmalForm utils", () => {
         },
       ]);
     });
-  });
 
-  describe("mapFormSnapshotToSummaryItems", () => {
-    it("should produce summary items object from fieldSnapshots", () => {
-      const summary = mapFormSnapshotToSummaryItems(fieldSnapshotsFixture);
-      expect(summary).toEqual([
+    it("should map form values to fieldSnapshots", () => {
+      const formSnapshot = mapAppFormToSnapshot({
+        values: kartleggingssporsmalFormFixture2,
+      });
+
+      expect(formSnapshot.fieldSnapshots).toEqual([
         {
-          id: "hvorSannsynligTilbakeTilJobben",
+          fieldId: "hvorSannsynligTilbakeTilJobben",
           label:
             "Hvor sannsynlig er det at du kommer tilbake i jobben du ble sykmeldt fra?",
-          value: "Jeg tror det er veldig sannsynlig",
+          description: null,
+          fieldType: "RADIO_GROUP",
+          options: [
+            {
+              optionId: "1a",
+              optionLabel: "Jeg tror det er veldig sannsynlig",
+              wasSelected: false,
+            },
+            {
+              optionId: "1b",
+              optionLabel: "Jeg tror det er lite sannsynlig",
+              wasSelected: true,
+            },
+            {
+              optionId: "1c",
+              optionLabel: "Jeg er usikker",
+              wasSelected: false,
+            },
+          ],
         },
         {
-          id: "samarbeidOgRelasjonTilArbeidsgiver",
+          fieldId: "hvorSannsynligTilbakeTilJobbenBegrunnelse",
+          label:
+            "Hvis du ønsker det kan du her utdype svaret ditt på forrige spørmsål. Det er valgfritt.",
+          description: "Svaret blir ikke delt med arbeidsgiveren din.",
+          fieldType: "TEXT",
+          value:
+            "Jeg tror det er lite sannsynlig fordi de ikke kan tilrettelegge for meg.",
+        },
+        {
+          fieldId: "samarbeidOgRelasjonTilArbeidsgiver",
           label:
             "Hvordan vil du beskrive samarbeidet og relasjonen mellom deg og arbeidsgiveren din?",
-          value: "Jeg opplever forholdet vårt som godt",
+          description: "Svaret blir ikke delt med din arbeidsgiver.",
+          fieldType: "RADIO_GROUP",
+          options: [
+            {
+              optionId: "2a",
+              optionLabel: "Jeg opplever samarbeidet og relasjonen som god",
+              wasSelected: true,
+            },
+            {
+              optionId: "2b",
+              optionLabel: "Jeg opplever samarbeidet og relasjonen som dårlig",
+              wasSelected: false,
+            },
+          ],
         },
         {
-          id: "naarTilbakeTilJobben",
-          label: "Hvor lenge tror du at du har behov for å være sykmeldt?",
-          value: "Mindre enn 26 uker (6 måneder) totalt",
+          fieldId: "naarTilbakeTilJobben",
+          label: "Hvor lenge tror du at du kommer til å være sykmeldt?",
+          description: null,
+          fieldType: "RADIO_GROUP",
+          options: [
+            {
+              optionId: "3a",
+              optionLabel: "Mindre enn seks måneder",
+              wasSelected: true,
+            },
+            {
+              optionId: "3b",
+              optionLabel: "Mer enn seks måneder",
+              wasSelected: false,
+            },
+          ],
         },
       ]);
+    });
+
+    it("should not include begrunnelse field when first answer is 1a", () => {
+      const formSnapshot = mapAppFormToSnapshot({
+        values: kartleggingssporsmalFormFixture3,
+      });
+
+      expect(
+        formSnapshot.fieldSnapshots.some(
+          (field) =>
+            field.fieldId === "hvorSannsynligTilbakeTilJobbenBegrunnelse",
+        ),
+      ).toBe(false);
     });
   });
 });

--- a/src/utils/kartleggingssporsmalForm.test.ts
+++ b/src/utils/kartleggingssporsmalForm.test.ts
@@ -111,7 +111,7 @@ describe("kartleggingssporsmalForm utils", () => {
         {
           fieldId: "hvorSannsynligTilbakeTilJobbenBegrunnelse",
           label:
-            "Hvis du ønsker det kan du her utdype svaret ditt på forrige spørmsål. Det er valgfritt.",
+            "Hvis du ønsker det kan du her utdype svaret ditt på forrige spørsmål. Det er valgfritt.",
           description: "Svaret blir ikke delt med arbeidsgiveren din.",
           fieldType: "TEXT",
           value:

--- a/src/utils/kartleggingssporsmalForm.ts
+++ b/src/utils/kartleggingssporsmalForm.ts
@@ -1,74 +1,84 @@
-import type { FormSummaryItem } from "@/features/kartleggingssporsmal/summary/KartleggingssporsmalFormSummary";
 import {
+  fieldIdsDisplayOrder,
   type KartleggingssporsmalForm,
   kartleggingssporsmalFormQuestions,
+  shouldIncludeTilbakeTilJobbBegrunnelseField,
 } from "@/forms/kartleggingssporsmalForm";
 import type {
   FieldSnapshots,
-  RadioGroupFieldSnapshot,
+  FormSnapshot,
 } from "@/services/meroppfolging/schemas/formSnapshotSchema";
 
-function withRadioFieldValues(values: KartleggingssporsmalForm) {
-  return <K extends keyof typeof kartleggingssporsmalFormQuestions>(
-    fieldId: K,
-  ): RadioGroupFieldSnapshot => {
+export const FORM_IDENTIFIER = "kartleggingssporsmal";
+export const FORM_SEMANTIC_VERSION = "1.0.0";
+export const FORM_SNAPSHOT_VERSION = "1.0.0";
+
+function mapAppFormToFieldSnapshots(
+  values: KartleggingssporsmalForm,
+): FieldSnapshots {
+  const includeJobbBegrunnelseField =
+    shouldIncludeTilbakeTilJobbBegrunnelseField(
+      values.hvorSannsynligTilbakeTilJobben,
+    );
+
+  const fields: FieldSnapshots = [];
+
+  for (const fieldId of fieldIdsDisplayOrder) {
     const question = kartleggingssporsmalFormQuestions[fieldId];
-    const selectedId = values[fieldId];
-    return {
-      fieldId,
-      label: question.label,
-      description: question.description,
-      fieldType: "RADIO_GROUP",
-      options: question.options.map((option) => ({
-        optionId: option.id,
-        optionLabel: option.label,
-        wasSelected: option.id === selectedId,
-      })),
-    };
-  };
+
+    switch (question.type) {
+      case "TEXT": {
+        if (
+          fieldId !== "hvorSannsynligTilbakeTilJobbenBegrunnelse" ||
+          (fieldId === "hvorSannsynligTilbakeTilJobbenBegrunnelse" &&
+            includeJobbBegrunnelseField)
+        ) {
+          fields.push({
+            fieldId,
+            label: question.label,
+            description: question.description,
+            fieldType: "TEXT",
+            value: values[fieldId] ?? "",
+          });
+        }
+
+        break;
+      }
+
+      case "RADIO_GROUP": {
+        const selectedId = values[fieldId];
+
+        fields.push({
+          fieldId,
+          label: question.label,
+          description: question.description,
+          fieldType: question.type,
+          options: question.options.map((option) => ({
+            optionId: option.id,
+            optionLabel: option.label,
+            wasSelected: option.id === selectedId,
+          })),
+        });
+
+        break;
+      }
+    }
+  }
+
+  return fields;
 }
 
 export function mapAppFormToSnapshot({
   values,
 }: {
   values: KartleggingssporsmalForm;
-}): FieldSnapshots {
-  const mapRadio = withRadioFieldValues(values);
+}): FormSnapshot {
+  const fieldSnapshots = mapAppFormToFieldSnapshots(values);
 
-  return [
-    mapRadio("hvorSannsynligTilbakeTilJobben"),
-    mapRadio("samarbeidOgRelasjonTilArbeidsgiver"),
-    mapRadio("naarTilbakeTilJobben"),
-  ];
-}
-
-export function mapFormSnapshotToSummaryItems(
-  snapshots: FieldSnapshots,
-): FormSummaryItem[] {
-  return snapshots.map((field) => {
-    switch (field.fieldType) {
-      case "RADIO_GROUP": {
-        const selectedOption = field.options.find(
-          (option) => option.wasSelected,
-        );
-        return {
-          id: field.fieldId,
-          label: field.label,
-          value: selectedOption?.optionLabel || "",
-        };
-      }
-      case "TEXT":
-        return {
-          id: field.fieldId,
-          label: field.label,
-          value: field.value,
-        };
-      // Missing 'fieldType' causes a compile-time error if we use the following check:
-      // https://gibbok.github.io/typescript-book/book/exhaustiveness-checking/
-      default: {
-        const _exhaustiveCheck: never = field;
-        return _exhaustiveCheck;
-      }
-    }
-  });
+  return {
+    formIdentifier: FORM_IDENTIFIER,
+    formSemanticVersion: FORM_SEMANTIC_VERSION,
+    formSnapshotVersion: FORM_SNAPSHOT_VERSION,
+    fieldSnapshots,
+  };
 }


### PR DESCRIPTION
Gi bruker mulighet til å utfylle svaret sitt i et tekstfelt når svaret på første spørsmål er "lite sannsynlig" eller "usikker" (1b/1c).

Endringer i pdfgen, backend og Modia må også gjøres klare før merge.

Demo: https://bro-frontend-demo-text-feild.ekstern.dev.nav.no/syk/kartleggingssporsmal

https://github.com/user-attachments/assets/6f827fe0-70d2-4bbb-8c60-5ba43c222ba9

Label-tekst er forslag og vurderes av designer.

- Extend form schema/questions/defaults with TEXT field.
- Define a display order for the form fields.
- Render the fields in the display order and conditionally include begrunnelse field.
- Map form values to form snapshot using the same field order and include the new field in snapshot mapping only when condition is met.
- Update FormSummary component to map directly from formSnapshot and show "Ingen tekst" for empty TEXT. Move the mapping logic to inside this component. Update the relateed test to be a component test instead of a function unit test.
- Add/adjust fixtures and tests for conditional field + snapshot/summary behavior.