### PR TITLE
refactor: clearer file names and organization

### DIFF
--- a/src/features/kartleggingssporsmal/form/KartleggingssporsmalForm.tsx
+++ b/src/features/kartleggingssporsmal/form/KartleggingssporsmalForm.tsx
@@ -5,12 +5,10 @@ import { logger } from "@navikt/next-logger";
 import { revalidateLogic } from "@tanstack/form-core";
 import { useState } from "react";
 import { logTaxonomyEvent } from "@/analytics/logTaxonomyEvent";
-import {
-  fieldIdsDisplayOrder,
-  kartleggingssporsmalFormQuestions,
-  kartleggingssporsmalFormSchema,
-  shouldIncludeTilbakeTilJobbBegrunnelseField,
-} from "@/forms/kartleggingssporsmalForm";
+import { shouldIncludeTilbakeTilJobbBegrunnelseField } from "@/forms/kartleggingssporsmal/conditional-fields-logic";
+import { fieldIdsDisplayOrder } from "@/forms/kartleggingssporsmal/fieldIdsDisplayOrder";
+import { kartleggingssporsmalFormQuestions } from "@/forms/kartleggingssporsmal/formQuestions";
+import { kartleggingssporsmalFormSchema } from "@/forms/kartleggingssporsmal/formSchema";
 import { useAppForm } from "@/hooks/form";
 import { submitFormAction } from "@/services/meroppfolging/actions/submitFormAction";
 import type { KartleggingssporsmalFormResponse } from "@/services/meroppfolging/schemas/formSnapshotSchema";

--- a/src/features/kartleggingssporsmal/form/formDefaultValues.ts
+++ b/src/features/kartleggingssporsmal/form/formDefaultValues.ts
@@ -1,4 +1,4 @@
-import type { KartleggingssporsmalForm } from "@/forms/kartleggingssporsmalForm";
+import type { KartleggingssporsmalForm } from "@/forms/kartleggingssporsmal/formSchema";
 
 type KartleggingssporsmalFormAlsoUnfilled = {
   [K in keyof KartleggingssporsmalForm]: KartleggingssporsmalForm[K] | "";

--- a/src/forms/kartleggingssporsmal/conditional-fields-logic.ts
+++ b/src/forms/kartleggingssporsmal/conditional-fields-logic.ts
@@ -1,0 +1,12 @@
+import type { KartleggingssporsmalForm } from "./formSchema";
+
+export function shouldIncludeTilbakeTilJobbBegrunnelseField(
+  hvorSannsynligTilbakeTilJobben:
+    | KartleggingssporsmalForm["hvorSannsynligTilbakeTilJobben"]
+    | "",
+): boolean {
+  return (
+    hvorSannsynligTilbakeTilJobben === "1b" ||
+    hvorSannsynligTilbakeTilJobben === "1c"
+  );
+}

--- a/src/forms/kartleggingssporsmal/fieldIdsDisplayOrder.ts
+++ b/src/forms/kartleggingssporsmal/fieldIdsDisplayOrder.ts
@@ -1,0 +1,8 @@
+import type { KartleggingsspormalFormQuestionId } from "./formQuestions";
+
+export const fieldIdsDisplayOrder: KartleggingsspormalFormQuestionId[] = [
+  "hvorSannsynligTilbakeTilJobben",
+  "hvorSannsynligTilbakeTilJobbenBegrunnelse",
+  "samarbeidOgRelasjonTilArbeidsgiver",
+  "naarTilbakeTilJobben",
+];

--- a/src/forms/kartleggingssporsmal/formQuestions.ts
+++ b/src/forms/kartleggingssporsmal/formQuestions.ts
@@ -1,26 +1,7 @@
-import { type ZodType, z } from "zod/v4";
 import type { RadioGroupQuestion } from "@/components/form-components/RadioGroup";
 import type { TextQuestion } from "@/components/form-components/TextArea";
 
-export const fieldIdsDisplayOrder: KartleggingsspormalFormQuestionId[] = [
-  "hvorSannsynligTilbakeTilJobben",
-  "hvorSannsynligTilbakeTilJobbenBegrunnelse",
-  "samarbeidOgRelasjonTilArbeidsgiver",
-  "naarTilbakeTilJobben",
-];
-
-export function shouldIncludeTilbakeTilJobbBegrunnelseField(
-  hvorSannsynligTilbakeTilJobben:
-    | KartleggingssporsmalForm["hvorSannsynligTilbakeTilJobben"]
-    | "",
-): boolean {
-  return (
-    hvorSannsynligTilbakeTilJobben === "1b" ||
-    hvorSannsynligTilbakeTilJobben === "1c"
-  );
-}
-
-const radioGroupQuestions = {
+export const radioGroupQuestions = {
   hvorSannsynligTilbakeTilJobben: {
     type: "RADIO_GROUP",
     label:
@@ -67,31 +48,5 @@ export const kartleggingssporsmalFormQuestions = {
   ...textQuestions,
 } as const;
 
-type KartleggingsspormalFormQuestionId =
+export type KartleggingsspormalFormQuestionId =
   keyof typeof kartleggingssporsmalFormQuestions;
-
-function getRadioGroupOptionIds(
-  radioFieldId: keyof typeof radioGroupQuestions,
-) {
-  return radioGroupQuestions[radioFieldId].options.map((option) => option.id);
-}
-
-export const kartleggingssporsmalFormSchema = z.object({
-  hvorSannsynligTilbakeTilJobben: z.enum(
-    getRadioGroupOptionIds("hvorSannsynligTilbakeTilJobben"),
-    "Feltet er påkrevd",
-  ),
-  hvorSannsynligTilbakeTilJobbenBegrunnelse: z.string(),
-  samarbeidOgRelasjonTilArbeidsgiver: z.enum(
-    getRadioGroupOptionIds("samarbeidOgRelasjonTilArbeidsgiver"),
-    "Feltet er påkrevd",
-  ),
-  naarTilbakeTilJobben: z.enum(
-    getRadioGroupOptionIds("naarTilbakeTilJobben"),
-    "Feltet er påkrevd",
-  ),
-} satisfies Record<KartleggingsspormalFormQuestionId, ZodType>);
-
-export type KartleggingssporsmalForm = z.infer<
-  typeof kartleggingssporsmalFormSchema
->;

--- a/src/forms/kartleggingssporsmal/formSchema.ts
+++ b/src/forms/kartleggingssporsmal/formSchema.ts
@@ -1,0 +1,31 @@
+import { type ZodType, z } from "zod";
+import {
+  type KartleggingsspormalFormQuestionId,
+  radioGroupQuestions,
+} from "./formQuestions";
+
+function getRadioGroupOptionIds(
+  radioFieldId: keyof typeof radioGroupQuestions,
+) {
+  return radioGroupQuestions[radioFieldId].options.map((option) => option.id);
+}
+
+export const kartleggingssporsmalFormSchema = z.object({
+  hvorSannsynligTilbakeTilJobben: z.enum(
+    getRadioGroupOptionIds("hvorSannsynligTilbakeTilJobben"),
+    "Feltet er påkrevd",
+  ),
+  hvorSannsynligTilbakeTilJobbenBegrunnelse: z.string(),
+  samarbeidOgRelasjonTilArbeidsgiver: z.enum(
+    getRadioGroupOptionIds("samarbeidOgRelasjonTilArbeidsgiver"),
+    "Feltet er påkrevd",
+  ),
+  naarTilbakeTilJobben: z.enum(
+    getRadioGroupOptionIds("naarTilbakeTilJobben"),
+    "Feltet er påkrevd",
+  ),
+} satisfies Record<KartleggingsspormalFormQuestionId, ZodType>);
+
+export type KartleggingssporsmalForm = z.infer<
+  typeof kartleggingssporsmalFormSchema
+>;

--- a/src/mocks/fixture/form.ts
+++ b/src/mocks/fixture/form.ts
@@ -1,4 +1,4 @@
-import type { KartleggingssporsmalForm } from "@/forms/kartleggingssporsmalForm";
+import type { KartleggingssporsmalForm } from "@/forms/kartleggingssporsmal/formSchema";
 import type { FieldSnapshots } from "@/services/meroppfolging/schemas/formSnapshotSchema";
 
 export const fieldSnapshotsFixture: FieldSnapshots = [

--- a/src/services/meroppfolging/actions/submitFormAction.ts
+++ b/src/services/meroppfolging/actions/submitFormAction.ts
@@ -6,13 +6,13 @@ import { verifyUserLoggedIn } from "@/auth/rsc";
 import { exchangeIdportenTokenForMeroppfolgingBackendTokenx } from "@/auth/tokenUtils";
 import { isLocalOrDemo } from "@/env-variables/envHelpers";
 import { getServerEnv } from "@/env-variables/serverEnv";
-import { kartleggingssporsmalFormSchema } from "@/forms/kartleggingssporsmalForm";
+import { kartleggingssporsmalFormSchema } from "@/forms/kartleggingssporsmal/formSchema";
 import {
   type FormSnapshotRequest,
   type SubmitKartleggingssporsmalResponse,
   submitKartleggingssporsmalResponseSchema,
 } from "@/services/meroppfolging/schemas/formSnapshotSchema";
-import { mapAppFormToSnapshot } from "@/utils/kartleggingssporsmalForm";
+import { mapAppFormToSnapshot } from "@/utils/kartleggingssporsmalFormSnapshot";
 
 export async function submitFormAction(
   formValues: unknown,

--- a/src/utils/kartleggingssporsmalFormSnapshot.test.ts
+++ b/src/utils/kartleggingssporsmalFormSnapshot.test.ts
@@ -4,9 +4,9 @@ import {
   kartleggingssporsmalFormFixture2,
   kartleggingssporsmalFormFixture3,
 } from "@/mocks/fixture/form";
-import { mapAppFormToSnapshot } from "@/utils/kartleggingssporsmalForm";
+import { mapAppFormToSnapshot } from "@/utils/kartleggingssporsmalFormSnapshot";
 
-describe("kartleggingssporsmalForm utils", () => {
+describe("kartleggingssporsmalFormSnapshot utils", () => {
   describe("mapAppFormToSnapshot", () => {
     it("should map form values to fieldSnapshots", () => {
       const formSnapshot = mapAppFormToSnapshot({

--- a/src/utils/kartleggingssporsmalFormSnapshot.ts
+++ b/src/utils/kartleggingssporsmalFormSnapshot.ts
@@ -1,9 +1,7 @@
-import {
-  fieldIdsDisplayOrder,
-  type KartleggingssporsmalForm,
-  kartleggingssporsmalFormQuestions,
-  shouldIncludeTilbakeTilJobbBegrunnelseField,
-} from "@/forms/kartleggingssporsmalForm";
+import { shouldIncludeTilbakeTilJobbBegrunnelseField } from "@/forms/kartleggingssporsmal/conditional-fields-logic";
+import { fieldIdsDisplayOrder } from "@/forms/kartleggingssporsmal/fieldIdsDisplayOrder";
+import { kartleggingssporsmalFormQuestions } from "@/forms/kartleggingssporsmal/formQuestions";
+import type { KartleggingssporsmalForm } from "@/forms/kartleggingssporsmal/formSchema";
 import type {
   FieldSnapshots,
   FormSnapshot,


### PR DESCRIPTION
Three files was named KartleggingssporsmalForm. Renaming files and splitting some code to multiple files.

- Move shared kartleggingssporsmal question and schema definitions into separate modules for schema and questions. Also separate files for field order and conditional field logic.
- Rename form snapshot mapping utility file.