### PR TITLE
Remove superfluous question description

### DIFF
--- a/src/forms/kartleggingssporsmalForm.ts
+++ b/src/forms/kartleggingssporsmalForm.ts
@@ -17,7 +17,7 @@ export const kartleggingssporsmalFormQuestions = {
     type: "RADIO_GROUP",
     label:
       "Hvordan vil du beskrive samarbeidet og relasjonen mellom deg og arbeidsgiveren din?",
-    description: "Svaret blir ikke delt med din arbeidsgiver.",
+    description: null,
     options: [
       { id: "2a", label: "Jeg opplever samarbeidet og relasjonen som god" },
       { id: "2b", label: "Jeg opplever samarbeidet og relasjonen som dårlig" },

--- a/src/mocks/fixture/form.ts
+++ b/src/mocks/fixture/form.ts
@@ -28,7 +28,7 @@ export const fieldSnapshotsFixture: FieldSnapshots = [
     label:
       "Hvordan vil du beskrive samarbeidet og relasjonen mellom deg og arbeidsgiveren din?",
     wasRequired: true,
-    description: "Svaret blir ikke delt med din arbeidsgiver.",
+    description: null,
     fieldId: "samarbeidOgRelasjonTilArbeidsgiver",
     options: [
       {

--- a/src/utils/kartleggingssporsmalForm.test.ts
+++ b/src/utils/kartleggingssporsmalForm.test.ts
@@ -44,7 +44,7 @@ describe("kartleggingssporsmalForm utils", () => {
           fieldId: "samarbeidOgRelasjonTilArbeidsgiver",
           label:
             "Hvordan vil du beskrive samarbeidet og relasjonen mellom deg og arbeidsgiveren din?",
-          description: "Svaret blir ikke delt med din arbeidsgiver.",
+          description: null,
           fieldType: "RADIO_GROUP",
           options: [
             {


### PR DESCRIPTION
Fjerne description-tekst om at svar ikke blir delt med arbeidsgiver fra det ene spørsmålet. Skulle egentlig vært fjernet når slik info ble lagt inn i FormHeaderAndTopText.

Oppdatering av journalføring: https://github.com/navikt/syfooppdfgen/pull/153