### PR TITLE
IS-3853: add form variant to Lumi context

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,12 @@ export default async function Home() {
   }
 
   if (formResponse) {
-    return <KartleggingssporsmalFormSummaryPage formResponse={formResponse} />;
+    return (
+      <KartleggingssporsmalFormSummaryPage
+        formResponse={formResponse}
+        formVariant={skjemavariant}
+      />
+    );
   }
 
   return (

--- a/src/components/lumi/lumi.tsx
+++ b/src/components/lumi/lumi.tsx
@@ -27,7 +27,7 @@ export const Lumi = ({ formVariant, isTextFieldVisible }: Props) => (
     survey={survey}
     transport={transport}
     context={{
-      tags: { formVariant, textFieldVisible: isTextFieldVisible },
+      tags: { skjemavariant: formVariant, textFieldVisible: isTextFieldVisible },
     }}
   />
 );

--- a/src/components/lumi/lumi.tsx
+++ b/src/components/lumi/lumi.tsx
@@ -3,6 +3,7 @@
 import { LumiSurveyDock, type LumiSurveyTransport } from "@navikt/lumi-survey";
 import { publicEnv } from "@/env-variables/publicEnv";
 import { intro, survey } from "./survey";
+import type { FormVariant } from "@/forms/kartleggingssporsmal/formVariants/types/FormVariant";
 
 const transport: LumiSurveyTransport = {
   async submit(submission) {
@@ -14,11 +15,19 @@ const transport: LumiSurveyTransport = {
   },
 };
 
-export const Lumi = () => (
+interface Props {
+  formVariant: FormVariant;
+  isTextFieldVisible: boolean;
+}
+
+export const Lumi = ({ formVariant, isTextFieldVisible }: Props) => (
   <LumiSurveyDock
     intro={intro}
     surveyId="bro-kartleggingssporsmal"
     survey={survey}
     transport={transport}
+    context={{
+      tags: { formVariant, textFieldVisible: isTextFieldVisible },
+    }}
   />
 );

--- a/src/features/kartleggingssporsmal/form/KartleggingssporsmalFormPage.tsx
+++ b/src/features/kartleggingssporsmal/form/KartleggingssporsmalFormPage.tsx
@@ -30,7 +30,10 @@ export default function KartleggingssporsmalFormPage({
   }, []);
 
   return formResponse ? (
-    <KartleggingssporsmalFormSummaryPage formResponse={formResponse} />
+    <KartleggingssporsmalFormSummaryPage
+      formResponse={formResponse}
+      formVariant={formVariant}
+    />
   ) : (
     <>
       {topContent}

--- a/src/features/kartleggingssporsmal/summary/KartleggingssporsmalFormSummaryPage.tsx
+++ b/src/features/kartleggingssporsmal/summary/KartleggingssporsmalFormSummaryPage.tsx
@@ -17,9 +17,9 @@ export default function KartleggingssporsmalFormSummaryPage({
   formVariant,
   formResponse: { formSnapshot, createdAt },
 }: Props) {
-  const isTextFieldVisible =
-    formSnapshot.fieldSnapshots.find((field) => field.fieldType === "TEXT") !==
-    undefined;
+  const isTextFieldVisible = formSnapshot.fieldSnapshots.some(
+    (field) => field.fieldType === "TEXT",
+  );
   return (
     <VStack gap="space-24">
       <Heading size={"large"} level="1">

--- a/src/features/kartleggingssporsmal/summary/KartleggingssporsmalFormSummaryPage.tsx
+++ b/src/features/kartleggingssporsmal/summary/KartleggingssporsmalFormSummaryPage.tsx
@@ -6,14 +6,20 @@ import ThankYouAlert from "@/features/kartleggingssporsmal/summary/ThankYouAlert
 import { UsefulLinks } from "@/features/kartleggingssporsmal/summary/UsefulLinks";
 import type { KartleggingssporsmalFormResponse } from "@/services/meroppfolging/schemas/requestsAndResponses";
 import KartleggingssporsmalFormSummary from "./KartleggingssporsmalFormSummary";
+import type { FormVariant } from "@/forms/kartleggingssporsmal/formVariants/types/FormVariant";
 
 type Props = {
   formResponse: KartleggingssporsmalFormResponse;
+  formVariant: FormVariant;
 };
 
 export default function KartleggingssporsmalFormSummaryPage({
+  formVariant,
   formResponse: { formSnapshot, createdAt },
 }: Props) {
+  const isTextFieldVisible =
+    formSnapshot.fieldSnapshots.find((field) => field.fieldType === "TEXT") !==
+    undefined;
   return (
     <VStack gap="space-24">
       <Heading size={"large"} level="1">
@@ -49,7 +55,7 @@ export default function KartleggingssporsmalFormSummaryPage({
         (åpner i ny fane) hvis det skulle være noe du lurer på.
       </BodyShort>
 
-      <Lumi />
+      <Lumi formVariant={formVariant} isTextFieldVisible={isTextFieldVisible} />
     </VStack>
   );
 }


### PR DESCRIPTION
<!-- Managed by esyfo-cli. Do not edit manually. Changes will be overwritten.
     For repo-specific customizations, create your own files without this header. -->
## Beskrivelse

Legger til `formVariant` og `textFieldVisible` i `context`på Lumi. Var litt usikker på navngivningen her så bare å komme med innspill. Også åpent til diskusjon om det er riktig å måle det på denne måten. `textFieldVisible` betyr vel slik det er nå at minst et tekstfelt var synlig når bruker sendte inn svarene. Det kan feks ha vært synlig, så har bruker endret et svaralternativ senere, slik at det ikke er synlig lenger. Det vil i så fall ikke bli plukket opp i slik det er nå. 

## Endringer

<!-- - `fil/modul`: Hva som ble endret -->

## Issue

<!-- Closes #NUMMER / Relates to #NUMMER -->

## Sjekkliste

- [ ] Koden kompilerer og linter uten feil
- [ ] Endringene er testet (manuelt eller automatisk)
- [ ] Ingen sensitiv data eksponert (tokens, credentials, PII)
