### PR TITLE
Remove lefthook config causing git problems

### DIFF
--- a/lefthook.json
+++ b/lefthook.json
@@ -14,12 +14,5 @@
         "run": "pnpm exec tsc --noEmit"
       }
     }
-  },
-  "commit-msg": {
-    "commands": {
-      "no-empty-commit": {
-        "run": "git diff --cached --quiet || exit 0; echo \"Nothing staged to commit. Empty commits are blocked to keep history clean.\"; exit 1"
-      }
-    }
   }
 }


### PR DESCRIPTION

## Beskrivelse

Fjerner lefthook config som skal forhindre tomme commiter.

Configen skaper problemer, fordi den blokkerer `--amend` og rebase+reword-operasjoner der du endrer meldingen på en tidligere commit. Den gjør at du ikke får endret meldingen på en tidligere commit uten at du også endrer innholdet i commiten.

Configen er nok uansett unødvendig. Git lar deg ikke commite uten endringer fra før, hvis du ikke bruker "--allow-empty".

Etter denne er merget  må kanskje utviklere kjøre `npx lefthook uninstall` og `npx lefthook install` for å få oppdatert hooks riktig i `.git/hooks`.