### PR TITLE
Remove biome config line degrading linting performance

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -6,8 +6,7 @@
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": true,
-    "includes": ["**", "!node_modules", "!.next", "!dist", "!build"]
+    "ignoreUnknown": true
   },
   "formatter": {
     "enabled": true,


### PR DESCRIPTION
## Beskrivelse

Jeg opplevde at vsocde kjører gradvis tregere og tregere. Å fjerne denne linjen fikset problemet.

Linjen fungerer nok ikke som tiltenkt selv om den ser ut til å eksludere "problem-mapper". Det virker som biome finner ut av det uten linjen.