### PR TITLE
docs: oppdater readme med korrekt wiki-lenke og intern-seksjon

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 
 ## Miljøer
 
-[🚀 Produksjon](https://www.nav.no/syk/kartleggingssporsmal)
+🚀 [Produksjon](https://www.nav.no/syk/kartleggingssporsmal)
 
-[🛠️ Utvikling](https://www.ekstern.dev.nav.no/syk/kartleggingssporsmal)
+🛠️ [Utvikling](https://www.ekstern.dev.nav.no/syk/kartleggingssporsmal)
 
-[🎬 Demo](https://demo.ekstern.dev.nav.no/syk/kartleggingssporsmal)
+🎬 [Demo](https://demo.ekstern.dev.nav.no/syk/kartleggingssporsmal)
 
 ## Formålet med appen
 
@@ -52,8 +52,14 @@ Brukte endepunkter:
 
 ## Utvikling (kjøre lokalt)
 
-For å komme i gang med bygging og kjøring av appen, les vår [wiki for Next.js-applikasjoner](https://github.com/navikt/esyfo-dev-tools/wiki/nextjs-build-run).
+For å komme i gang med å bygge og kjøre appen, se vår [Wiki for frontendapper](https://navikt.github.io/team-esyfo/utvikling/frontend/).
 
 Når appen er startet, åpne http://localhost:3000/syk/kartleggingssporsmal
+
+## For Nav-ansatte
+
+Interne henvendelser kan sendes via Slack i kanalen [#esyfo](https://nav-it.slack.com/archives/C012X796B4L).
+
+---
 
 [^basepath]: `basePath`-verdien settes i Next.js-konfigurasjonen i `next.config.ts` og angir URL-prefikset som hele appen lever under.


### PR DESCRIPTION
## Beskrivelse

Oppdaterer README med korrekt lenke til ny wiki for frontendapper, og legger til en seksjon for Nav-ansatte med Slack-kanal.

## Endringer

- `README.md`: Fikser emoji-plassering i miljølenker (utenfor klikkbart område)
- `README.md`: Oppdaterer wiki-lenke fra gammel GitHub-wiki til ny dokumentasjonsside
- `README.md`: Legger til «For Nav-ansatte»-seksjon med Slack-kanal

## Issue

Ingen tilknyttet issue.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)