### PR TITLE
IS-3960 Add new skjemavariant FLERVALG_FRITEKST_V2

### DIFF
--- a/src/components/form-components/RadioGroup.tsx
+++ b/src/components/form-components/RadioGroup.tsx
@@ -5,6 +5,7 @@ import { useFieldContext } from "@/hooks/form";
 type RadioOption = {
   id: string;
   label: string;
+  description?: string;
 };
 
 export type RadioGroupQuestion = {
@@ -47,7 +48,11 @@ export function RadioGroup({ question, isRequired }: Props) {
       error={field.state.meta.errors[0]?.message}
     >
       {question.options.map((option) => (
-        <Radio key={option.id} value={option.id}>
+        <Radio
+          key={option.id}
+          value={option.id}
+          description={option.description}
+        >
           {option.label}
         </Radio>
       ))}

--- a/src/forms/kartleggingssporsmal/fieldSchemas/fieldSchemas.ts
+++ b/src/forms/kartleggingssporsmal/fieldSchemas/fieldSchemas.ts
@@ -28,7 +28,7 @@ export const fieldSchemas = {
     getRadioGroupOptionIds("arbeidsgiverFaarDuOppfolgingFlervalg"),
     requiredFieldErrorMessage,
   ),
-  arbeidsgiverFaarDuOppfolgningNeiBegrunnelse: z
+  arbeidsgiverFaarDuOppfolgingNeiBegrunnelse: z
     .string()
     .max(TEXT_AREA_MAX_LENGTH, maxLengthErrorMessage),
   naarTilbakeTilJobbenFlervalg: z.enum(

--- a/src/forms/kartleggingssporsmal/fieldSchemas/fieldSchemas.ts
+++ b/src/forms/kartleggingssporsmal/fieldSchemas/fieldSchemas.ts
@@ -24,6 +24,13 @@ export const fieldSchemas = {
   arbeidsgiverSamarbeidDarligBegrunnelse: z
     .string()
     .max(TEXT_AREA_MAX_LENGTH, maxLengthErrorMessage),
+  arbeidsgiverFaarDuOppfolgingFlervalg: z.enum(
+    getRadioGroupOptionIds("arbeidsgiverFaarDuOppfolgingFlervalg"),
+    requiredFieldErrorMessage,
+  ),
+  arbeidsgiverFaarDuOppfolgningNeiBegrunnelse: z
+    .string()
+    .max(TEXT_AREA_MAX_LENGTH, maxLengthErrorMessage),
   naarTilbakeTilJobbenFlervalg: z.enum(
     getRadioGroupOptionIds("naarTilbakeTilJobbenFlervalg"),
     requiredFieldErrorMessage,

--- a/src/forms/kartleggingssporsmal/formVariants/formDefaultValues.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/formDefaultValues.ts
@@ -22,7 +22,7 @@ const formDefaultValuesByFormVariant: {
     tilbakeTilJobbenLiteSannsynligBegrunnelse: "",
     tilbakeTilJobbenUsikkerBegrunnelse: "",
     arbeidsgiverFaarDuOppfolgingFlervalg: "",
-    arbeidsgiverFaarDuOppfolgningNeiBegrunnelse: "",
+    arbeidsgiverFaarDuOppfolgingNeiBegrunnelse: "",
     naarTilbakeTilJobbenFlervalg: "",
   },
 };

--- a/src/forms/kartleggingssporsmal/formVariants/formDefaultValues.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/formDefaultValues.ts
@@ -17,6 +17,14 @@ const formDefaultValuesByFormVariant: {
     arbeidsgiverSamarbeidDarligBegrunnelse: "",
     naarTilbakeTilJobbenFlervalg: "",
   },
+  FLERVALG_FRITEKST_V2: {
+    tilbakeTilJobbenHvorSannsynligFlervalg: "",
+    tilbakeTilJobbenLiteSannsynligBegrunnelse: "",
+    tilbakeTilJobbenUsikkerBegrunnelse: "",
+    arbeidsgiverFaarDuOppfolgingFlervalg: "",
+    arbeidsgiverFaarDuOppfolgningNeiBegrunnelse: "",
+    naarTilbakeTilJobbenFlervalg: "",
+  },
 };
 
 export function getFormDefaultValuesForFormVariant<T extends FormVariant>(

--- a/src/forms/kartleggingssporsmal/formVariants/formVariantConfigs/flervalgFritekstV2Config.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/formVariantConfigs/flervalgFritekstV2Config.ts
@@ -1,0 +1,52 @@
+import z from "zod";
+import { fieldSchemas } from "../../fieldSchemas/fieldSchemas";
+import type { KartleggingsspormalFormFieldId } from "../../questions/allQuestions";
+import { defineVariantConfig } from "../types/FormVariantConfig";
+
+export const flervalgFritekstV2Config = defineVariantConfig({
+  formFields: [
+    {
+      fieldId: "tilbakeTilJobbenHvorSannsynligFlervalg",
+      isRequired: true,
+    },
+    {
+      fieldId: "tilbakeTilJobbenLiteSannsynligBegrunnelse",
+      isRequired: false,
+      conditionallyIncludeIf: (formValues) =>
+        formValues.tilbakeTilJobbenHvorSannsynligFlervalg === "1b",
+    },
+    {
+      fieldId: "tilbakeTilJobbenUsikkerBegrunnelse",
+      isRequired: false,
+      conditionallyIncludeIf: (formValues) =>
+        formValues.tilbakeTilJobbenHvorSannsynligFlervalg === "1c",
+    },
+    {
+      fieldId: "arbeidsgiverFaarDuOppfolgingFlervalg",
+      isRequired: true,
+    },
+    {
+      fieldId: "arbeidsgiverFaarDuOppfolgningNeiBegrunnelse",
+      isRequired: false,
+      conditionallyIncludeIf: (formValues) =>
+        formValues.arbeidsgiverFaarDuOppfolgingFlervalg === "nei",
+    },
+    {
+      fieldId: "naarTilbakeTilJobbenFlervalg",
+      isRequired: true,
+    },
+  ],
+  validationSchema: z.object({
+    tilbakeTilJobbenHvorSannsynligFlervalg:
+      fieldSchemas.tilbakeTilJobbenHvorSannsynligFlervalg,
+    tilbakeTilJobbenLiteSannsynligBegrunnelse:
+      fieldSchemas.tilbakeTilJobbenLiteSannsynligBegrunnelse,
+    tilbakeTilJobbenUsikkerBegrunnelse:
+      fieldSchemas.tilbakeTilJobbenUsikkerBegrunnelse,
+    arbeidsgiverFaarDuOppfolgingFlervalg:
+      fieldSchemas.arbeidsgiverFaarDuOppfolgingFlervalg,
+    arbeidsgiverFaarDuOppfolgningNeiBegrunnelse:
+      fieldSchemas.arbeidsgiverFaarDuOppfolgningNeiBegrunnelse,
+    naarTilbakeTilJobbenFlervalg: fieldSchemas.naarTilbakeTilJobbenFlervalg,
+  } satisfies Partial<Record<KartleggingsspormalFormFieldId, z.ZodType>>),
+});

--- a/src/forms/kartleggingssporsmal/formVariants/formVariantConfigs/flervalgFritekstV2Config.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/formVariantConfigs/flervalgFritekstV2Config.ts
@@ -26,7 +26,7 @@ export const flervalgFritekstV2Config = defineVariantConfig({
       isRequired: true,
     },
     {
-      fieldId: "arbeidsgiverFaarDuOppfolgningNeiBegrunnelse",
+      fieldId: "arbeidsgiverFaarDuOppfolgingNeiBegrunnelse",
       isRequired: false,
       conditionallyIncludeIf: (formValues) =>
         formValues.arbeidsgiverFaarDuOppfolgingFlervalg === "nei",
@@ -45,8 +45,8 @@ export const flervalgFritekstV2Config = defineVariantConfig({
       fieldSchemas.tilbakeTilJobbenUsikkerBegrunnelse,
     arbeidsgiverFaarDuOppfolgingFlervalg:
       fieldSchemas.arbeidsgiverFaarDuOppfolgingFlervalg,
-    arbeidsgiverFaarDuOppfolgningNeiBegrunnelse:
-      fieldSchemas.arbeidsgiverFaarDuOppfolgningNeiBegrunnelse,
+    arbeidsgiverFaarDuOppfolgingNeiBegrunnelse:
+      fieldSchemas.arbeidsgiverFaarDuOppfolgingNeiBegrunnelse,
     naarTilbakeTilJobbenFlervalg: fieldSchemas.naarTilbakeTilJobbenFlervalg,
   } satisfies Partial<Record<KartleggingsspormalFormFieldId, z.ZodType>>),
 });

--- a/src/forms/kartleggingssporsmal/formVariants/formVariants.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/formVariants.ts
@@ -1,4 +1,5 @@
 import { flervalgFritekstV1Config } from "./formVariantConfigs/flervalgFritekstV1Config";
+import { flervalgFritekstV2Config } from "./formVariantConfigs/flervalgFritekstV2Config";
 import { flervalgV1Config } from "./formVariantConfigs/flervalgV1Config";
 import type { FormVariant } from "./types/FormVariant";
 
@@ -9,11 +10,16 @@ import type { FormVariant } from "./types/FormVariant";
  * in the candidate table in `meroppfolging-backend`, and can no longer enter
  * that table).
  */
-export const formVariants = ["FLERVALG_V1", "FLERVALG_FRITEKST_V1"] as const;
+export const formVariants = [
+  "FLERVALG_V1",
+  "FLERVALG_FRITEKST_V1",
+  "FLERVALG_FRITEKST_V2",
+] as const;
 
 export const formVariantConfigs = {
   FLERVALG_V1: flervalgV1Config,
   FLERVALG_FRITEKST_V1: flervalgFritekstV1Config,
+  FLERVALG_FRITEKST_V2: flervalgFritekstV2Config,
 } satisfies Record<FormVariant, unknown>;
 
 export function getValidationSchemaForVariant(formVariant: FormVariant) {

--- a/src/forms/kartleggingssporsmal/questions/radioGroupQuestions.ts
+++ b/src/forms/kartleggingssporsmal/questions/radioGroupQuestions.ts
@@ -26,7 +26,7 @@ export const radioGroupQuestions = {
     type: "RADIO_GROUP",
     label: "Får du oppfølging av arbeidsgiveren din nå når du er sykmeldt?",
     description:
-      "Arbeidsgiveren din har hovedansvaret for å gjøre tilpasninger og følge deg opp på arbeidsplassen. Arbeidsgiver har for eksempel plikt til å lage en oppfølgingsplan med deg innen uke 4. Derfor er det viktig at dere har tett kontakt når du er sykmeldt.",
+      "Arbeidsgiveren din har hovedansvaret for å gjøre tilpasninger og følge deg opp på arbeidsplassen. Arbeidsgiver har for eksempel plikt til å lage en oppfølgingsplan med deg innen du har vært sykmeldt i fire uker. Derfor er det viktig at dere har tett kontakt når du er sykmeldt.",
     options: [
       {
         id: "ja",
@@ -36,7 +36,8 @@ export const radioGroupQuestions = {
       {
         id: "nei",
         label:
-          "Nei, jeg opplever manglende oppfølging og at tilrettelegging er vanskelig.",
+          "Nei, jeg opplever manglende oppfølging og at tilpasninger er vanskelig.",
+        description: "Du får mulighet til å utdype mer",
       },
     ],
   },

--- a/src/forms/kartleggingssporsmal/questions/radioGroupQuestions.ts
+++ b/src/forms/kartleggingssporsmal/questions/radioGroupQuestions.ts
@@ -22,6 +22,24 @@ export const radioGroupQuestions = {
       { id: "2b", label: "Jeg opplever samarbeidet og relasjonen som dårlig" },
     ],
   },
+  arbeidsgiverFaarDuOppfolgingFlervalg: {
+    type: "RADIO_GROUP",
+    label: "Får du oppfølging av arbeidsgiveren din nå når du er sykmeldt?",
+    description:
+      "Arbeidsgiveren din har hovedansvaret for å gjøre tilpasninger og følge deg opp på arbeidsplassen. Arbeidsgiver har for eksempel plikt til å lage en oppfølgingsplan med deg innen uke 4. Derfor er det viktig at dere har tett kontakt når du er sykmeldt.",
+    options: [
+      {
+        id: "ja",
+        label:
+          "Ja, jeg får oppfølging, og har snakket med arbeidsgiver om dette.",
+      },
+      {
+        id: "nei",
+        label:
+          "Nei, jeg opplever manglende oppfølging og at tilrettelegging er vanskelig.",
+      },
+    ],
+  },
   naarTilbakeTilJobbenFlervalg: {
     type: "RADIO_GROUP",
     label: "Hvor lenge tror du at du kommer til å være sykmeldt?",

--- a/src/forms/kartleggingssporsmal/questions/textQuestions.ts
+++ b/src/forms/kartleggingssporsmal/questions/textQuestions.ts
@@ -19,7 +19,7 @@ export const textQuestions = {
     description:
       "Skriv kort om hva som gjør samarbeidet og relasjonen dårlig og hvordan dette påvirker oppfølgingen du får fra arbeidsgiver. Ikke skriv detaljerte opplysninger om helse, personlige opplysninger eller opplysninger om andre enn deg selv.",
   },
-  arbeidsgiverFaarDuOppfolgningNeiBegrunnelse: {
+  arbeidsgiverFaarDuOppfolgingNeiBegrunnelse: {
     type: "TEXT",
     label:
       "Hva savner du i samarbeidet med arbeidsgiver for at du skal få bedre oppfølging?",

--- a/src/forms/kartleggingssporsmal/questions/textQuestions.ts
+++ b/src/forms/kartleggingssporsmal/questions/textQuestions.ts
@@ -19,4 +19,11 @@ export const textQuestions = {
     description:
       "Skriv kort om hva som gjør samarbeidet og relasjonen dårlig og hvordan dette påvirker oppfølgingen du får fra arbeidsgiver. Ikke skriv detaljerte opplysninger om helse, personlige opplysninger eller opplysninger om andre enn deg selv.",
   },
+  arbeidsgiverFaarDuOppfolgningNeiBegrunnelse: {
+    type: "TEXT",
+    label:
+      "Hva savner du i samarbeidet med arbeidsgiver for at du skal få bedre oppfølging?",
+    description:
+      "Skriv kort om hva du har behov for og hva som er vanskelig. Svaret ditt er kun synlig for Nav, og blir ikke delt med din arbeidsgiver.  Ikke skriv detaljerte opplysninger om helse, personlige opplysninger eller opplysninger om andre enn deg selv.",
+  },
 } as const satisfies Record<string, TextQuestion>;

--- a/src/services/meroppfolging/meroppfolgingService.ts
+++ b/src/services/meroppfolging/meroppfolgingService.ts
@@ -13,7 +13,7 @@ export async function fetchKandidatStatus(): Promise<KandidatStatusResponse> {
   if (isLocalOrDemo) {
     return {
       isKandidat: true,
-      skjemavariant: "FLERVALG_FRITEKST_V1",
+      skjemavariant: "FLERVALG_FRITEKST_V2",
       formResponse: null, //kartleggingssporsmalFormResponseFixture,
     };
   }


### PR DESCRIPTION
## Beskrivelse

Legger til skjemavariant FLERVALG_FRITEKST_V2 basert på FLERVALG_FRITEKST_V1, men der spørsmål 2 er endret fra å handle om relasjon til arbeidsgiver til å være mer fokusert på oppfølging fra arbeidsgiver. Det er da nye formuleringer i label og description for det andre flervalgsspørsmålet og det betingetde fritekstfeltet knyttet til det.

<img width="779" height="675" alt="image" src="https://github.com/user-attachments/assets/40caa884-40c9-453b-90cd-4744bb757f36" />

## Endringer

- `formVariantConfigs`: Legger til variant-config for FLERVALG_FRITEKST_V2.
- `fieldSchemas`: Legger til nye zod skjemaer for de to nye feltene.
- `radioGroupQuestions`: Legger til tekster for nytt flervalg-spørsmål.
- `textQuestions`: Legger til tekster for nytt fritekst-spørsmål.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)

