### PR TITLE
Improve useDemoSkjemaVariant hook

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -76,9 +76,11 @@ const RootLayout = async ({
                     gutters
                   >
                     {isLocalOrDemo && <DemoInfoCard />}
+
                     {children}
                   </PageBlock>
                 </div>
+
                 {isLocalOrDemo && (
                   <Suspense fallback={null}>
                     <DemoVariantButton />

--- a/src/components/demo-form-variant/DemoVariantButton.tsx
+++ b/src/components/demo-form-variant/DemoVariantButton.tsx
@@ -4,16 +4,13 @@ import { Button } from "@navikt/ds-react";
 import { useState } from "react";
 import type { FormVariant } from "@/forms/kartleggingssporsmal/formVariants/types/FormVariant";
 import DemoVariantPickerModal from "./DemoVariantPickerModal";
-import {
-  DEFAULT_DEMO_FORM_VARIANT,
-  useDemoFormVariantViaParamIfDemo,
-} from "./useDemoFormVariant";
+import { useDemoFormVariant } from "./useDemoFormVariant";
 
 export default function DemoVariantButton() {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const { activeFormVariant, changeDemoFormVariantViaParam } =
-    useDemoFormVariantViaParamIfDemo(DEFAULT_DEMO_FORM_VARIANT);
+  const { demoFormVariant, changeDemoFormVariantViaParam } =
+    useDemoFormVariant();
 
   function openModal() {
     setIsModalOpen(true);
@@ -46,7 +43,7 @@ export default function DemoVariantButton() {
 
       <DemoVariantPickerModal
         open={isModalOpen}
-        activeVariant={activeFormVariant}
+        activeDemoVariant={demoFormVariant}
         onClose={closeModal}
         onSelectVariant={handleChangeDemoFormVariant}
       />

--- a/src/components/demo-form-variant/DemoVariantButton.tsx
+++ b/src/components/demo-form-variant/DemoVariantButton.tsx
@@ -4,13 +4,13 @@ import { Button } from "@navikt/ds-react";
 import { useState } from "react";
 import type { FormVariant } from "@/forms/kartleggingssporsmal/formVariants/types/FormVariant";
 import DemoVariantPickerModal from "./DemoVariantPickerModal";
-import { useDemoFormVariant } from "./useDemoFormVariant";
+import { useDemoFormVariantUrlParam } from "./useDemoFormVariant";
 
 export default function DemoVariantButton() {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const { demoFormVariant, changeDemoFormVariantViaParam } =
-    useDemoFormVariant();
+  const { demoFormVariant, changeDemoVariantViaUrlParam } =
+    useDemoFormVariantUrlParam();
 
   function openModal() {
     setIsModalOpen(true);
@@ -20,8 +20,8 @@ export default function DemoVariantButton() {
     setIsModalOpen(false);
   }
 
-  function handleChangeDemoFormVariant(variant: FormVariant) {
-    changeDemoFormVariantViaParam(variant);
+  function handleChangeCurrentDemoVariant(variant: FormVariant) {
+    changeDemoVariantViaUrlParam(variant);
     closeModal();
   }
 
@@ -43,9 +43,9 @@ export default function DemoVariantButton() {
 
       <DemoVariantPickerModal
         open={isModalOpen}
-        activeDemoVariant={demoFormVariant}
+        currentDemoVariant={demoFormVariant}
         onClose={closeModal}
-        onSelectVariant={handleChangeDemoFormVariant}
+        onChangeCurrentDemoVariant={handleChangeCurrentDemoVariant}
       />
     </>
   );

--- a/src/components/demo-form-variant/DemoVariantPickerModal.tsx
+++ b/src/components/demo-form-variant/DemoVariantPickerModal.tsx
@@ -34,12 +34,16 @@ export default function DemoVariantPickerModal({
     }
   }, [open, currentDemoVariant]);
 
+  function reloadPage() {
+    window.location.reload();
+  }
+
   return (
     <Modal
       open={open}
       onClose={onClose}
       header={{
-        heading: "Velg skjemavariant i demovisningen",
+        heading: "Valg for demovisning",
         size: "small",
         closeButton: false,
       }}
@@ -47,6 +51,10 @@ export default function DemoVariantPickerModal({
     >
       <Modal.Body>
         <VStack gap="space-16">
+          <Button className="self-start" onClick={reloadPage}>
+            Tilbakestill skjema
+          </Button>
+
           <RadioGroup
             legend="Velg skjemavariant"
             name={DEMO_SKJEMAVARIANT_URL_PARAM_KEY}

--- a/src/components/demo-form-variant/DemoVariantPickerModal.tsx
+++ b/src/components/demo-form-variant/DemoVariantPickerModal.tsx
@@ -8,7 +8,7 @@ import type { FormVariant } from "@/forms/kartleggingssporsmal/formVariants/type
 
 interface Props {
   open: boolean;
-  activeVariant: FormVariant;
+  activeDemoVariant: FormVariant;
   onClose: () => void;
   onSelectVariant: (value: FormVariant) => void;
 }
@@ -21,17 +21,17 @@ const formVariantModalDescriptions: Record<FormVariant, string> = {
 
 export default function DemoVariantPickerModal({
   open,
-  activeVariant,
+  activeDemoVariant,
   onClose,
   onSelectVariant,
 }: Props) {
-  const [selectedVariant, setSelectedVariant] = useState(activeVariant);
+  const [selectedVariant, setSelectedVariant] = useState(activeDemoVariant);
 
   useEffect(() => {
     if (open) {
-      setSelectedVariant(activeVariant);
+      setSelectedVariant(activeDemoVariant);
     }
-  }, [open, activeVariant]);
+  }, [open, activeDemoVariant]);
 
   return (
     <Modal

--- a/src/components/demo-form-variant/DemoVariantPickerModal.tsx
+++ b/src/components/demo-form-variant/DemoVariantPickerModal.tsx
@@ -8,9 +8,9 @@ import type { FormVariant } from "@/forms/kartleggingssporsmal/formVariants/type
 
 interface Props {
   open: boolean;
-  activeDemoVariant: FormVariant;
+  currentDemoVariant: FormVariant;
   onClose: () => void;
-  onSelectVariant: (value: FormVariant) => void;
+  onChangeCurrentDemoVariant: (value: FormVariant) => void;
 }
 
 const formVariantModalDescriptions: Record<FormVariant, string> = {
@@ -21,17 +21,18 @@ const formVariantModalDescriptions: Record<FormVariant, string> = {
 
 export default function DemoVariantPickerModal({
   open,
-  activeDemoVariant,
+  currentDemoVariant,
   onClose,
-  onSelectVariant,
+  onChangeCurrentDemoVariant,
 }: Props) {
-  const [selectedVariant, setSelectedVariant] = useState(activeDemoVariant);
+  const [selectedRadioVariant, setSelectedRadioVariant] =
+    useState(currentDemoVariant);
 
   useEffect(() => {
     if (open) {
-      setSelectedVariant(activeDemoVariant);
+      setSelectedRadioVariant(currentDemoVariant);
     }
-  }, [open, activeDemoVariant]);
+  }, [open, currentDemoVariant]);
 
   return (
     <Modal
@@ -49,8 +50,8 @@ export default function DemoVariantPickerModal({
           <RadioGroup
             legend="Velg skjemavariant"
             name={DEMO_SKJEMAVARIANT_URL_PARAM_KEY}
-            value={selectedVariant}
-            onChange={(value) => setSelectedVariant(value as FormVariant)}
+            value={selectedRadioVariant}
+            onChange={(value) => setSelectedRadioVariant(value as FormVariant)}
           >
             {formVariants.map((variant) => (
               <Radio
@@ -66,7 +67,12 @@ export default function DemoVariantPickerModal({
       </Modal.Body>
 
       <Modal.Footer>
-        <Button onClick={() => onSelectVariant(selectedVariant)}>Ok</Button>
+        <Button
+          onClick={() => onChangeCurrentDemoVariant(selectedRadioVariant)}
+        >
+          Ok
+        </Button>
+
         <Button variant="tertiary" onClick={onClose}>
           Avbryt
         </Button>

--- a/src/components/demo-form-variant/useDemoFormVariant.ts
+++ b/src/components/demo-form-variant/useDemoFormVariant.ts
@@ -16,22 +16,19 @@ export const DEFAULT_DEMO_FORM_VARIANT: FormVariant = "FLERVALG_V1";
  * Using the hook in a demo environment when the URL parameter is not set or
  * invalid will cause the URL to be updated with the default demo variant.
  */
-export function useDemoFormVariantViaParamIfDemo(
-  formVariantIfNotInDemo: FormVariant,
-) {
+export function useDemoFormVariant() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
 
-  let activeFormVariant = formVariantIfNotInDemo;
+  let demoFormVariant = DEFAULT_DEMO_FORM_VARIANT;
 
   const demoVariantFromUrl = searchParams.get(DEMO_SKJEMAVARIANT_URL_PARAM_KEY);
   const parseVariantResult = formVariantSchema.safeParse(demoVariantFromUrl);
 
-  // Override form variant with the one from URL parameter if we're in a demo
-  // environment
+  // Read demo variant from URL parameter
   if (parseVariantResult.success && isLocalOrDemo) {
-    activeFormVariant = parseVariantResult.data;
+    demoFormVariant = parseVariantResult.data;
   }
 
   const changeDemoFormVariantViaParam = useCallback(
@@ -59,7 +56,7 @@ export function useDemoFormVariantViaParamIfDemo(
   }, [parseVariantResult.success, changeDemoFormVariantViaParam]);
 
   return {
-    activeFormVariant,
+    demoFormVariant,
     changeDemoFormVariantViaParam,
   };
 }

--- a/src/components/demo-form-variant/useDemoFormVariant.ts
+++ b/src/components/demo-form-variant/useDemoFormVariant.ts
@@ -7,16 +7,17 @@ import {
   formVariantSchema,
 } from "@/forms/kartleggingssporsmal/formVariants/types/FormVariant";
 
+// Set IS_DEMO_VARIANT_URL_PARAM_ENABLED to `isDemo` to test locally with mock
+// backend variant value instead of variant from URL parameter.
+export const IS_DEMO_VARIANT_URL_PARAM_ENABLED = isLocalOrDemo;
 export const DEFAULT_DEMO_FORM_VARIANT: FormVariant = "FLERVALG_V1";
 
 /**
  * This hook handles the logic for determining which form variant to display in
  * demo environments, based on a URL parameter. It also provides a function to
  * update this URL parameter, so different form variants can be tested.
- * Using the hook in a demo environment when the URL parameter is not set or
- * invalid will cause the URL to be updated with the default demo variant.
  */
-export function useDemoFormVariant() {
+export function useDemoFormVariantUrlParam() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
@@ -24,14 +25,17 @@ export function useDemoFormVariant() {
   let demoFormVariant = DEFAULT_DEMO_FORM_VARIANT;
 
   const demoVariantFromUrl = searchParams.get(DEMO_SKJEMAVARIANT_URL_PARAM_KEY);
-  const parseVariantResult = formVariantSchema.safeParse(demoVariantFromUrl);
+  const parseVariantUrlParamResult =
+    formVariantSchema.safeParse(demoVariantFromUrl);
+
+  const isValidVariantUrlParam = parseVariantUrlParamResult.success;
 
   // Read demo variant from URL parameter
-  if (parseVariantResult.success && isLocalOrDemo) {
-    demoFormVariant = parseVariantResult.data;
+  if (isValidVariantUrlParam) {
+    demoFormVariant = parseVariantUrlParamResult.data;
   }
 
-  const changeDemoFormVariantViaParam = useCallback(
+  const changeDemoVariantViaUrlParam = useCallback(
     (variant: FormVariant, options?: { replaceUrl?: boolean }) => {
       const params = new URLSearchParams(searchParams.toString());
       params.set(DEMO_SKJEMAVARIANT_URL_PARAM_KEY, variant);
@@ -45,18 +49,26 @@ export function useDemoFormVariant() {
     [router, pathname, searchParams],
   );
 
-  // Side effect: update URL if we're in a demo environment and URL parameter is
-  // missing or is invalid.
+  return {
+    demoFormVariant,
+    isValidVariantUrlParam,
+    changeDemoVariantViaUrlParam,
+  };
+}
+
+/**
+ * Using this hook in a demo environment when the URL parameter is not set or
+ * invalid will cause the URL to be updated with the default demo variant.
+ */
+export const useEnsureVariantUrlParamIfDemoEffect = () => {
+  const { isValidVariantUrlParam, changeDemoVariantViaUrlParam } =
+    useDemoFormVariantUrlParam();
+
   useEffect(() => {
-    if (!parseVariantResult.success && isLocalOrDemo) {
-      changeDemoFormVariantViaParam(DEFAULT_DEMO_FORM_VARIANT, {
+    if (!isValidVariantUrlParam && IS_DEMO_VARIANT_URL_PARAM_ENABLED) {
+      changeDemoVariantViaUrlParam(DEFAULT_DEMO_FORM_VARIANT, {
         replaceUrl: true,
       });
     }
-  }, [parseVariantResult.success, changeDemoFormVariantViaParam]);
-
-  return {
-    demoFormVariant,
-    changeDemoFormVariantViaParam,
-  };
-}
+  }, [isValidVariantUrlParam, changeDemoVariantViaUrlParam]);
+};

--- a/src/components/demo-form-variant/useDemoFormVariant.ts
+++ b/src/components/demo-form-variant/useDemoFormVariant.ts
@@ -18,9 +18,9 @@ export const DEFAULT_DEMO_FORM_VARIANT: FormVariant = "FLERVALG_V1";
  * update this URL parameter, so different form variants can be tested.
  */
 export function useDemoFormVariantUrlParam() {
-  const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
 
   let demoFormVariant = DEFAULT_DEMO_FORM_VARIANT;
 

--- a/src/features/kartleggingssporsmal/form/KartleggingssporsmalFormPage.tsx
+++ b/src/features/kartleggingssporsmal/form/KartleggingssporsmalFormPage.tsx
@@ -51,6 +51,7 @@ export default function KartleggingssporsmalFormPage({
       {topContent}
 
       <KartleggingssporsmalForm
+        key={formVariantToUse} // Reset form state when variant changes
         formVariant={formVariantToUse}
         setSummaryItems={setFormResponse}
       />

--- a/src/features/kartleggingssporsmal/form/KartleggingssporsmalFormPage.tsx
+++ b/src/features/kartleggingssporsmal/form/KartleggingssporsmalFormPage.tsx
@@ -2,8 +2,11 @@
 
 import { useEffect, useState } from "react";
 import { logTaxonomyEvent } from "@/analytics/logTaxonomyEvent";
-import { useDemoFormVariant } from "@/components/demo-form-variant/useDemoFormVariant";
-import { isLocalOrDemo } from "@/env-variables/envHelpers";
+import {
+  IS_DEMO_VARIANT_URL_PARAM_ENABLED,
+  useDemoFormVariantUrlParam,
+  useEnsureVariantUrlParamIfDemoEffect,
+} from "@/components/demo-form-variant/useDemoFormVariant";
 import type { FormVariant } from "@/forms/kartleggingssporsmal/formVariants/types/FormVariant";
 import type { KartleggingssporsmalFormResponse } from "@/services/meroppfolging/schemas/requestsAndResponses";
 import KartleggingssporsmalFormSummaryPage from "../summary/KartleggingssporsmalFormSummaryPage";
@@ -21,9 +24,10 @@ export default function KartleggingssporsmalFormPage({
   const [formResponse, setFormResponse] =
     useState<KartleggingssporsmalFormResponse | null>(null);
 
-  const { demoFormVariant } = useDemoFormVariant();
+  const { demoFormVariant } = useDemoFormVariantUrlParam();
+  useEnsureVariantUrlParamIfDemoEffect();
 
-  const formVariantToUse = isLocalOrDemo
+  const formVariantToUse = IS_DEMO_VARIANT_URL_PARAM_ENABLED
     ? demoFormVariant
     : formVariantFromBackend;
 
@@ -47,9 +51,6 @@ export default function KartleggingssporsmalFormPage({
       {topContent}
 
       <KartleggingssporsmalForm
-        // key prop is used to remount the component when activeFormVariant
-        // changes
-        key={formVariantToUse}
         formVariant={formVariantToUse}
         setSummaryItems={setFormResponse}
       />

--- a/src/features/kartleggingssporsmal/form/KartleggingssporsmalFormPage.tsx
+++ b/src/features/kartleggingssporsmal/form/KartleggingssporsmalFormPage.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState } from "react";
 import { logTaxonomyEvent } from "@/analytics/logTaxonomyEvent";
-import { useDemoFormVariantViaParamIfDemo } from "@/components/demo-form-variant/useDemoFormVariant";
+import { useDemoFormVariant } from "@/components/demo-form-variant/useDemoFormVariant";
+import { isLocalOrDemo } from "@/env-variables/envHelpers";
 import type { FormVariant } from "@/forms/kartleggingssporsmal/formVariants/types/FormVariant";
 import type { KartleggingssporsmalFormResponse } from "@/services/meroppfolging/schemas/requestsAndResponses";
 import KartleggingssporsmalFormSummaryPage from "../summary/KartleggingssporsmalFormSummaryPage";
@@ -20,9 +21,11 @@ export default function KartleggingssporsmalFormPage({
   const [formResponse, setFormResponse] =
     useState<KartleggingssporsmalFormResponse | null>(null);
 
-  const { activeFormVariant } = useDemoFormVariantViaParamIfDemo(
-    formVariantFromBackend,
-  );
+  const { demoFormVariant } = useDemoFormVariant();
+
+  const formVariantToUse = isLocalOrDemo
+    ? demoFormVariant
+    : formVariantFromBackend;
 
   useEffect(() => {
     logTaxonomyEvent({
@@ -37,7 +40,7 @@ export default function KartleggingssporsmalFormPage({
   return formResponse ? (
     <KartleggingssporsmalFormSummaryPage
       formResponse={formResponse}
-      formVariant={activeFormVariant}
+      formVariant={formVariantToUse}
     />
   ) : (
     <>
@@ -46,8 +49,8 @@ export default function KartleggingssporsmalFormPage({
       <KartleggingssporsmalForm
         // key prop is used to remount the component when activeFormVariant
         // changes
-        key={activeFormVariant}
-        formVariant={activeFormVariant}
+        key={formVariantToUse}
+        formVariant={formVariantToUse}
         setSummaryItems={setFormResponse}
       />
     </>

--- a/src/services/meroppfolging/meroppfolgingService.ts
+++ b/src/services/meroppfolging/meroppfolgingService.ts
@@ -13,7 +13,7 @@ export async function fetchKandidatStatus(): Promise<KandidatStatusResponse> {
   if (isLocalOrDemo) {
     return {
       isKandidat: true,
-      skjemavariant: "FLERVALG_FRITEKST_V2",
+      skjemavariant: "FLERVALG_V1",
       formResponse: null, //kartleggingssporsmalFormResponseFixture,
     };
   }


### PR DESCRIPTION
## Beskrivelse

Dette er litt forenkling og forbedring av `useDemoSkjemaVariant`. Når demo-variant ikke er satt med url-parameter setter den demo-skjemavariant til det samme som useEnsureVariantUrlParamIfDemoEffect vil endre den til. Dette gjør at det ikke blir et raskt skifte fra en variant til en annen i demo.

Ansvaret for å bruke demoVariant fra hooken eller variant fra backend plasseres ut til call site i KargleggingssparsmalFormPage, så hooken kun tar seg av å støtte demo-miljø, og hooken trenger da ikke lenger ta inn parameter for backend variant.

Effekt-hooken useEnsureVariantUrlParamIfDemoEffect er splittet ut som egen hook slik at den kan brukes kun en gang selv om useDemoSkjemaVariant brukes i flere komponenter.