### PR TITLE
feat: add new skjemavariant FLERVALG_FRITEKST_V3

### DIFF
--- a/src/components/demo-form-variant/DemoVariantPickerModal.tsx
+++ b/src/components/demo-form-variant/DemoVariantPickerModal.tsx
@@ -16,7 +16,8 @@ interface Props {
 const formVariantModalDescriptions: Record<FormVariant, string> = {
   FLERVALG_V1: "I bruk for de fleste pilotkontorer",
   FLERVALG_FRITEKST_V1: "Fases ut",
-  FLERVALG_FRITEKST_V2: "I bruk for Sandefjord, Asker og Søndre Nordstrand",
+  FLERVALG_FRITEKST_V2: "Fases ut",
+  FLERVALG_FRITEKST_V3: "I bruk for Sandefjord, Asker og Søndre Nordstrand",
 };
 
 export default function DemoVariantPickerModal({

--- a/src/forms/kartleggingssporsmal/fieldSchemas/fieldSchemas.ts
+++ b/src/forms/kartleggingssporsmal/fieldSchemas/fieldSchemas.ts
@@ -17,6 +17,15 @@ export const fieldSchemas = {
   tilbakeTilJobbenUsikkerBegrunnelse: z
     .string()
     .max(TEXT_AREA_MAX_LENGTH, maxLengthErrorMessage),
+
+  mulighetForTilbakeTilJobbenFlervalg: z.enum(
+    getRadioGroupOptionIds("mulighetForTilbakeTilJobbenFlervalg"),
+    requiredFieldErrorMessage,
+  ),
+  mulighetForTilbakeTilJobbenUtfordrendeBegrunnelse: z
+    .string()
+    .max(TEXT_AREA_MAX_LENGTH, maxLengthErrorMessage),
+
   arbeidsgiverHvordanErSamarbeidFlervalg: z.enum(
     getRadioGroupOptionIds("arbeidsgiverHvordanErSamarbeidFlervalg"),
     requiredFieldErrorMessage,
@@ -31,6 +40,7 @@ export const fieldSchemas = {
   arbeidsgiverFaarDuOppfolgingNeiBegrunnelse: z
     .string()
     .max(TEXT_AREA_MAX_LENGTH, maxLengthErrorMessage),
+
   naarTilbakeTilJobbenFlervalg: z.enum(
     getRadioGroupOptionIds("naarTilbakeTilJobbenFlervalg"),
     requiredFieldErrorMessage,

--- a/src/forms/kartleggingssporsmal/formVariants/formDefaultValues.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/formDefaultValues.ts
@@ -25,6 +25,13 @@ const formDefaultValuesByFormVariant: {
     arbeidsgiverFaarDuOppfolgingNeiBegrunnelse: "",
     naarTilbakeTilJobbenFlervalg: "",
   },
+  FLERVALG_FRITEKST_V3: {
+    mulighetForTilbakeTilJobbenFlervalg: "",
+    mulighetForTilbakeTilJobbenUtfordrendeBegrunnelse: "",
+    arbeidsgiverFaarDuOppfolgingFlervalg: "",
+    arbeidsgiverFaarDuOppfolgingNeiBegrunnelse: "",
+    naarTilbakeTilJobbenFlervalg: "",
+  },
 };
 
 export function getFormDefaultValuesForFormVariant<T extends FormVariant>(

--- a/src/forms/kartleggingssporsmal/formVariants/formVariantConfigs/flervalgFritekstV3Config.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/formVariantConfigs/flervalgFritekstV3Config.ts
@@ -1,0 +1,44 @@
+import z from "zod";
+import { fieldSchemas } from "../../fieldSchemas/fieldSchemas";
+import type { KartleggingsspormalFormFieldId } from "../../questions/allQuestions";
+import { defineVariantConfig } from "../types/FormVariantConfig";
+
+export const flervalgFritekstV3Config = defineVariantConfig({
+  formFields: [
+    {
+      fieldId: "mulighetForTilbakeTilJobbenFlervalg",
+      isRequired: true,
+    },
+    {
+      fieldId: "mulighetForTilbakeTilJobbenUtfordrendeBegrunnelse",
+      isRequired: false,
+      conditionallyIncludeIf: (formValues) =>
+        formValues.mulighetForTilbakeTilJobbenFlervalg === "utfordrende",
+    },
+    {
+      fieldId: "arbeidsgiverFaarDuOppfolgingFlervalg",
+      isRequired: true,
+    },
+    {
+      fieldId: "arbeidsgiverFaarDuOppfolgingNeiBegrunnelse",
+      isRequired: false,
+      conditionallyIncludeIf: (formValues) =>
+        formValues.arbeidsgiverFaarDuOppfolgingFlervalg === "nei",
+    },
+    {
+      fieldId: "naarTilbakeTilJobbenFlervalg",
+      isRequired: true,
+    },
+  ],
+  validationSchema: z.object({
+    mulighetForTilbakeTilJobbenFlervalg:
+      fieldSchemas.mulighetForTilbakeTilJobbenFlervalg,
+    mulighetForTilbakeTilJobbenUtfordrendeBegrunnelse:
+      fieldSchemas.mulighetForTilbakeTilJobbenUtfordrendeBegrunnelse,
+    arbeidsgiverFaarDuOppfolgingFlervalg:
+      fieldSchemas.arbeidsgiverFaarDuOppfolgingFlervalg,
+    arbeidsgiverFaarDuOppfolgingNeiBegrunnelse:
+      fieldSchemas.arbeidsgiverFaarDuOppfolgingNeiBegrunnelse,
+    naarTilbakeTilJobbenFlervalg: fieldSchemas.naarTilbakeTilJobbenFlervalg,
+  } satisfies Partial<Record<KartleggingsspormalFormFieldId, z.ZodType>>),
+});

--- a/src/forms/kartleggingssporsmal/formVariants/formVariants.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/formVariants.ts
@@ -1,5 +1,6 @@
 import { flervalgFritekstV1Config } from "./formVariantConfigs/flervalgFritekstV1Config";
 import { flervalgFritekstV2Config } from "./formVariantConfigs/flervalgFritekstV2Config";
+import { flervalgFritekstV3Config } from "./formVariantConfigs/flervalgFritekstV3Config";
 import { flervalgV1Config } from "./formVariantConfigs/flervalgV1Config";
 import type { FormVariant } from "./types/FormVariant";
 
@@ -14,12 +15,14 @@ export const formVariants = [
   "FLERVALG_V1",
   "FLERVALG_FRITEKST_V1",
   "FLERVALG_FRITEKST_V2",
+  "FLERVALG_FRITEKST_V3",
 ] as const;
 
 export const formVariantConfigs = {
   FLERVALG_V1: flervalgV1Config,
   FLERVALG_FRITEKST_V1: flervalgFritekstV1Config,
   FLERVALG_FRITEKST_V2: flervalgFritekstV2Config,
+  FLERVALG_FRITEKST_V3: flervalgFritekstV3Config,
 } satisfies Record<FormVariant, unknown>;
 
 export function getValidationSchemaForVariant(formVariant: FormVariant) {

--- a/src/forms/kartleggingssporsmal/questions/radioGroupQuestions.ts
+++ b/src/forms/kartleggingssporsmal/questions/radioGroupQuestions.ts
@@ -12,6 +12,26 @@ export const radioGroupQuestions = {
       { id: "1c", label: "Jeg er usikker" },
     ],
   },
+  mulighetForTilbakeTilJobbenFlervalg: {
+    type: "RADIO_GROUP",
+    label:
+      "Hvordan ser du for deg muligheten for å komme tilbake til din nåværende jobb og stilling?",
+    description:
+      "Tenk over om du tror du kan komme helt eller delvis tilbake til din nåværende jobb og stilling, eller om du ser det som utfordrende.",
+    options: [
+      {
+        id: "kommer_tilbake",
+        label:
+          "Jeg har tro på at jeg kommer tilbake til samme jobb og stilling",
+      },
+      {
+        id: "utfordrende",
+        label:
+          "Jeg ser på det som utfordrende å komme tilbake til samme jobb og stilling",
+        description: "Du får mulighet til å utdype mer",
+      },
+    ],
+  },
   arbeidsgiverHvordanErSamarbeidFlervalg: {
     type: "RADIO_GROUP",
     label:

--- a/src/forms/kartleggingssporsmal/questions/textQuestions.ts
+++ b/src/forms/kartleggingssporsmal/questions/textQuestions.ts
@@ -13,6 +13,13 @@ export const textQuestions = {
     description:
       "Skriv kort hvorfor du er usikker. Ikke skriv detaljerte opplysninger om helse, personlige opplysninger eller opplysninger om andre enn deg selv.",
   },
+  mulighetForTilbakeTilJobbenUtfordrendeBegrunnelse: {
+    type: "TEXT",
+    label:
+      "Beskriv hva som er utfordrende, og hva du tror kan hjelpe deg videre",
+    description:
+      "Ikke skriv detaljerte opplysninger om helse, personlige opplysninger eller opplysninger om andre enn deg selv.",
+  },
   arbeidsgiverSamarbeidDarligBegrunnelse: {
     type: "TEXT",
     label: "Hva gjør samarbeidet og relasjonen dårlig?",


### PR DESCRIPTION
## Beskrivelse

Legger til en ny skjemavariant `FLERVALG_FRITEKST_V3` basert på `FLERVALG_FRITEKST_V2`, der spørsmål 1 er endret fra å handle om hvor sannsynlig det er at man kommer tilbake til jobb til å handle om hvor stor muligheten er for å komme tilbake til nåværende jobb og stilling.

## Endringer
* `formVariants` og `formVariantConfigs`: Legger til ny konfig variant for `FLERVALG_FRITEKST_V3`
* `fieldSchemas`: Legger til nye zod skjemaer for de nye feltene.
* `radioGroupQuestions`: Legger til tekster for nytt flervalg-spørsmål.
* `textQuestions`: Legger til tekster for nytt fritekst-spørsmål.

## Issue

Ingen issue

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
