### PR TITLE
fix: schema validation failing to parse no candidate response

### DIFF
--- a/src/services/meroppfolging/schemas/requestsAndResponses.ts
+++ b/src/services/meroppfolging/schemas/requestsAndResponses.ts
@@ -21,11 +21,18 @@ export type SubmitKartleggingssporsmalResponse = z.infer<
   typeof submitKartleggingssporsmalResponseSchema
 >;
 
-export const kandidatStatusResponseSchema = z.object({
-  isKandidat: z.boolean(),
-  skjemavariant: formVariantSchema,
-  formResponse: kartleggingssporsmalFormResponseSchema.nullable(),
-});
+export const kandidatStatusResponseSchema = z.union([
+  z.object({
+    isKandidat: z.literal(true),
+    skjemavariant: formVariantSchema,
+    formResponse: kartleggingssporsmalFormResponseSchema.nullable(),
+  }),
+  z.object({
+    isKandidat: z.literal(false),
+    skjemavariant: z.null(),
+    formResponse: z.null(),
+  }),
+]);
 export type KandidatStatusResponse = z.infer<
   typeof kandidatStatusResponseSchema
 >;


### PR DESCRIPTION
## Beskrivelse
Fikser opp i skjemavalidering for brukere som ikke er kandidater.

## Endringer

`requestAndResponses`: Endrer zod-skjema til å ta i bruk union for å støtte de forskjellige responsene

## Issue

Ingen issue

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
