### PR TITLE
Mer semantisk konfig for "utdyp mer" description på options i visse varianter

### DIFF
--- a/src/components/demo-form-variant/useDemoFormVariant.ts
+++ b/src/components/demo-form-variant/useDemoFormVariant.ts
@@ -10,7 +10,7 @@ import {
 // Set IS_DEMO_VARIANT_URL_PARAM_ENABLED to `isDemo` to test locally with mock
 // backend variant value instead of variant from URL parameter.
 export const IS_DEMO_VARIANT_URL_PARAM_ENABLED = isLocalOrDemo;
-export const DEFAULT_DEMO_FORM_VARIANT: FormVariant = "FLERVALG_V1";
+export const DEFAULT_DEMO_FORM_VARIANT: FormVariant = "FLERVALG_V2";
 
 /**
  * This hook handles the logic for determining which form variant to display in

--- a/src/components/form-components/RadioGroup.tsx
+++ b/src/components/form-components/RadioGroup.tsx
@@ -7,10 +7,10 @@ type RadioOption = {
   label: string;
   description?: string;
   /**
-   * If `canTriggerAdditionOfFritekstField` for the corresponding field
+   * If `someOptionsTriggerAdditionOfFritekstField` for the corresponding field
    * in the form variant config is true, then this description is used.
    */
-  descriptionWhenOptionTriggersAdditionOfTextField?: string;
+  descriptionWhenOptionTriggersAdditionOfTextFieldInVariant?: string;
 };
 
 export type RadioGroupQuestion = {

--- a/src/components/form-components/RadioGroup.tsx
+++ b/src/components/form-components/RadioGroup.tsx
@@ -6,6 +6,11 @@ type RadioOption = {
   id: string;
   label: string;
   description?: string;
+  /**
+   * If `canTriggerAdditionOfFritekstField` for the corresponding field
+   * in the form variant config is true, then this description is used.
+   */
+  descriptionWhenOptionTriggersAdditionOfTextField?: string;
 };
 
 export type RadioGroupQuestion = {

--- a/src/features/kartleggingssporsmal/form/KartleggingssporsmalForm.tsx
+++ b/src/features/kartleggingssporsmal/form/KartleggingssporsmalForm.tsx
@@ -6,7 +6,7 @@ import { revalidateLogic } from "@tanstack/form-core";
 import { useState } from "react";
 import { logTaxonomyEvent } from "@/analytics/logTaxonomyEvent";
 import { getValidationSchemaForVariant } from "@/forms/kartleggingssporsmal/formVariants/formVariants";
-import { getFieldsToIncludeInFormInOrder } from "@/forms/kartleggingssporsmal/formVariants/getFieldsToIncludeInForm";
+import { renderFieldsToIncludeInFormInOrder } from "@/forms/kartleggingssporsmal/formVariants/renderFieldsToIncludeInForm";
 import type { FormVariant } from "@/forms/kartleggingssporsmal/formVariants/types/FormVariant";
 import { useAppForm } from "@/hooks/form";
 import { submitFormAction } from "@/services/meroppfolging/actions/submitFormAction";
@@ -84,7 +84,7 @@ export default function KartleggingssporsmalForm({
         <div className="grid gap-4 mb-4">
           <form.Subscribe selector={(state) => state.values}>
             {(formValues) => {
-              return getFieldsToIncludeInFormInOrder(
+              return renderFieldsToIncludeInFormInOrder(
                 formVariant,
                 formValues,
               ).map(({ fieldId, question, isRequired }) => (

--- a/src/forms/kartleggingssporsmal/formVariants/formVariantConfigs/flervalgFritekstV1Config.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/formVariantConfigs/flervalgFritekstV1Config.ts
@@ -12,13 +12,13 @@ export const flervalgFritekstV1Config = defineVariantConfig({
     {
       fieldId: "tilbakeTilJobbenLiteSannsynligBegrunnelse",
       isRequired: false,
-      conditionallyIncludeIf: (formValues) =>
+      conditionallyAddIf: (formValues) =>
         formValues.tilbakeTilJobbenHvorSannsynligFlervalg === "1b",
     },
     {
       fieldId: "tilbakeTilJobbenUsikkerBegrunnelse",
       isRequired: false,
-      conditionallyIncludeIf: (formValues) =>
+      conditionallyAddIf: (formValues) =>
         formValues.tilbakeTilJobbenHvorSannsynligFlervalg === "1c",
     },
     {
@@ -28,7 +28,7 @@ export const flervalgFritekstV1Config = defineVariantConfig({
     {
       fieldId: "arbeidsgiverSamarbeidDarligBegrunnelse",
       isRequired: false,
-      conditionallyIncludeIf: (formValues) =>
+      conditionallyAddIf: (formValues) =>
         formValues.arbeidsgiverHvordanErSamarbeidFlervalg === "2b",
     },
     {

--- a/src/forms/kartleggingssporsmal/formVariants/formVariantConfigs/flervalgFritekstV2Config.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/formVariantConfigs/flervalgFritekstV2Config.ts
@@ -12,13 +12,13 @@ export const flervalgFritekstV2Config = defineVariantConfig({
     {
       fieldId: "tilbakeTilJobbenLiteSannsynligBegrunnelse",
       isRequired: false,
-      conditionallyIncludeIf: (formValues) =>
+      conditionallyAddIf: (formValues) =>
         formValues.tilbakeTilJobbenHvorSannsynligFlervalg === "1b",
     },
     {
       fieldId: "tilbakeTilJobbenUsikkerBegrunnelse",
       isRequired: false,
-      conditionallyIncludeIf: (formValues) =>
+      conditionallyAddIf: (formValues) =>
         formValues.tilbakeTilJobbenHvorSannsynligFlervalg === "1c",
     },
     {
@@ -29,7 +29,7 @@ export const flervalgFritekstV2Config = defineVariantConfig({
     {
       fieldId: "arbeidsgiverFaarDuOppfolgingNeiBegrunnelse",
       isRequired: false,
-      conditionallyIncludeIf: (formValues) =>
+      conditionallyAddIf: (formValues) =>
         formValues.arbeidsgiverFaarDuOppfolgingFlervalg === "nei",
     },
     {

--- a/src/forms/kartleggingssporsmal/formVariants/formVariantConfigs/flervalgFritekstV2Config.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/formVariantConfigs/flervalgFritekstV2Config.ts
@@ -24,7 +24,7 @@ export const flervalgFritekstV2Config = defineVariantConfig({
     {
       fieldId: "arbeidsgiverFaarDuOppfolgingFlervalg",
       isRequired: true,
-      canTriggerAdditionOfFritekstField: true,
+      someOptionsTriggerAdditionOfFritekstField: true,
     },
     {
       fieldId: "arbeidsgiverFaarDuOppfolgingNeiBegrunnelse",

--- a/src/forms/kartleggingssporsmal/formVariants/formVariantConfigs/flervalgFritekstV2Config.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/formVariantConfigs/flervalgFritekstV2Config.ts
@@ -24,7 +24,7 @@ export const flervalgFritekstV2Config = defineVariantConfig({
     {
       fieldId: "arbeidsgiverFaarDuOppfolgingFlervalg",
       isRequired: true,
-      showOptionDescriptions: true,
+      canTriggerAdditionOfFritekstField: true,
     },
     {
       fieldId: "arbeidsgiverFaarDuOppfolgingNeiBegrunnelse",

--- a/src/forms/kartleggingssporsmal/formVariants/formVariantConfigs/flervalgFritekstV3Config.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/formVariantConfigs/flervalgFritekstV3Config.ts
@@ -8,7 +8,7 @@ export const flervalgFritekstV3Config = defineVariantConfig({
     {
       fieldId: "mulighetForTilbakeTilJobbenFlervalg",
       isRequired: true,
-      showOptionDescriptions: true,
+      canTriggerAdditionOfFritekstField: true,
     },
     {
       fieldId: "mulighetForTilbakeTilJobbenUtfordrendeBegrunnelse",
@@ -19,7 +19,7 @@ export const flervalgFritekstV3Config = defineVariantConfig({
     {
       fieldId: "arbeidsgiverFaarDuOppfolgingFlervalg",
       isRequired: true,
-      showOptionDescriptions: true,
+      canTriggerAdditionOfFritekstField: true,
     },
     {
       fieldId: "arbeidsgiverFaarDuOppfolgingNeiBegrunnelse",

--- a/src/forms/kartleggingssporsmal/formVariants/formVariantConfigs/flervalgFritekstV3Config.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/formVariantConfigs/flervalgFritekstV3Config.ts
@@ -8,7 +8,7 @@ export const flervalgFritekstV3Config = defineVariantConfig({
     {
       fieldId: "mulighetForTilbakeTilJobbenFlervalg",
       isRequired: true,
-      canTriggerAdditionOfFritekstField: true,
+      someOptionsTriggerAdditionOfFritekstField: true,
     },
     {
       fieldId: "mulighetForTilbakeTilJobbenUtfordrendeBegrunnelse",
@@ -19,7 +19,7 @@ export const flervalgFritekstV3Config = defineVariantConfig({
     {
       fieldId: "arbeidsgiverFaarDuOppfolgingFlervalg",
       isRequired: true,
-      canTriggerAdditionOfFritekstField: true,
+      someOptionsTriggerAdditionOfFritekstField: true,
     },
     {
       fieldId: "arbeidsgiverFaarDuOppfolgingNeiBegrunnelse",

--- a/src/forms/kartleggingssporsmal/formVariants/formVariantConfigs/flervalgFritekstV3Config.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/formVariantConfigs/flervalgFritekstV3Config.ts
@@ -13,7 +13,7 @@ export const flervalgFritekstV3Config = defineVariantConfig({
     {
       fieldId: "mulighetForTilbakeTilJobbenUtfordrendeBegrunnelse",
       isRequired: false,
-      conditionallyIncludeIf: (formValues) =>
+      conditionallyAddIf: (formValues) =>
         formValues.mulighetForTilbakeTilJobbenFlervalg === "utfordrende",
     },
     {
@@ -24,7 +24,7 @@ export const flervalgFritekstV3Config = defineVariantConfig({
     {
       fieldId: "arbeidsgiverFaarDuOppfolgingNeiBegrunnelse",
       isRequired: false,
-      conditionallyIncludeIf: (formValues) =>
+      conditionallyAddIf: (formValues) =>
         formValues.arbeidsgiverFaarDuOppfolgingFlervalg === "nei",
     },
     {

--- a/src/forms/kartleggingssporsmal/formVariants/getFieldsToIncludeInForm.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/getFieldsToIncludeInForm.ts
@@ -7,7 +7,7 @@ import { formVariantConfigs } from "./formVariants";
 import type { FormValuesForVariant } from "./types/FormValues";
 import type { FormVariant } from "./types/FormVariant";
 
-type FieldData = {
+type RenderedFieldData = {
   fieldId: KartleggingsspormalFormFieldId;
   question: Question;
   isRequired: boolean;
@@ -24,35 +24,70 @@ type FieldData = {
 export function getFieldsToIncludeInFormInOrder<T extends FormVariant>(
   formVariant: T,
   formValues: FormValuesForVariant<T>,
-): Array<FieldData> {
+): Array<RenderedFieldData> {
   const fieldsConfigForVariant = formVariantConfigs[formVariant].formFields;
 
-  const filteredByIncludeIf = fieldsConfigForVariant.filter((fieldConfig) =>
-    fieldConfig.conditionallyIncludeIf
-      ? fieldConfig.conditionallyIncludeIf(formValues)
-      : true,
+  const filteredByConditionalFields = fieldsConfigForVariant.filter(
+    (fieldConfig) =>
+      fieldConfig.conditionallyIncludeIf
+        ? fieldConfig.conditionallyIncludeIf(formValues)
+        : true,
   );
 
-  const mappedToFieldData: FieldData[] = filteredByIncludeIf.map(
-    ({ fieldId, isRequired, showOptionDescriptions }) => {
-      const question = allKartleggingssporsmalQuestions[fieldId];
-
-      return {
+  const mappedToFieldData: RenderedFieldData[] =
+    filteredByConditionalFields.map(
+      ({
         fieldId,
-        question:
-          question.type === "RADIO_GROUP" && !showOptionDescriptions
-            ? {
-                ...question,
-                options: question.options.map(({ id, label }) => ({
-                  id,
-                  label,
-                })),
-              }
-            : question,
         isRequired,
-      };
-    },
-  );
+        canTriggerAdditionOfFritekstField:
+          canTriggerAdditionOfFritekstFieldInThisVariant,
+      }) => {
+        const question = allKartleggingssporsmalQuestions[fieldId];
+
+        return {
+          fieldId,
+          isRequired,
+          question: applyFritekstTriggerDescriptionsToQuestion(
+            question,
+            canTriggerAdditionOfFritekstFieldInThisVariant || false,
+          ),
+        };
+      },
+    );
 
   return mappedToFieldData;
+}
+
+/**
+ * For radio group questions where selecting an option can trigger the
+ * addition of a fritekst field, appends each option's
+ * descriptionWhenOptionTriggersAdditionOfTextField to its description so
+ * users are told upfront that elaborating is possible. Left unchanged for
+ * other question types or when the trigger flag is not set for this variant.
+ */
+function applyFritekstTriggerDescriptionsToQuestion(
+  question: Question,
+  canTriggerAdditionOfFritekstFieldInThisVariant: boolean,
+): Question {
+  if (
+    question.type !== "RADIO_GROUP" ||
+    !canTriggerAdditionOfFritekstFieldInThisVariant
+  ) {
+    return question;
+  }
+
+  return {
+    ...question,
+    options: question.options.map((option) => ({
+      ...option,
+      // Combine both descriptions if present, otherwise use whichever one is set.
+      description:
+        [
+          option.description,
+          option.descriptionWhenOptionTriggersAdditionOfTextField,
+        ]
+          .filter(Boolean)
+          .join(" ") || undefined,
+    })),
+  };
 }

--- a/src/forms/kartleggingssporsmal/formVariants/renderFieldsToIncludeInForm.test.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/renderFieldsToIncludeInForm.test.ts
@@ -4,7 +4,7 @@ import { getFormDefaultValuesForFormVariant } from "./formDefaultValues";
 import { renderFieldsToIncludeInFormInOrder } from "./renderFieldsToIncludeInForm";
 import type { FormVariant } from "./types/FormVariant";
 
-describe("getFieldsToIncludeInForm", () => {
+describe("renderFieldsToIncludeInForm", () => {
   it("returns the full field list for FLERVALG_V1", () => {
     expect(
       renderFieldsToIncludeInFormInOrder(

--- a/src/forms/kartleggingssporsmal/formVariants/renderFieldsToIncludeInForm.test.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/renderFieldsToIncludeInForm.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { KartleggingsspormalFormFieldId } from "../questions/allQuestions";
 import { getFormDefaultValuesForFormVariant } from "./formDefaultValues";
-import { getFieldsToIncludeInFormInOrder } from "./getFieldsToIncludeInForm";
+import { renderFieldsToIncludeInFormInOrder } from "./renderFieldsToIncludeInForm";
 import type { FormVariant } from "./types/FormVariant";
 
 describe("getFieldsToIncludeInForm", () => {
   it("returns the full field list for FLERVALG_V1", () => {
     expect(
-      getFieldsToIncludeInFormInOrder(
+      renderFieldsToIncludeInFormInOrder(
         "FLERVALG_V1",
         getFormDefaultValuesForFormVariant("FLERVALG_V1"),
       ).map((field) => field.fieldId),
@@ -29,7 +29,7 @@ describe("getFieldsToIncludeInForm", () => {
       "FLERVALG_FRITEKST_V1",
     );
 
-    const fieldIdsWhenSannsynlig = getFieldsToIncludeInFormInOrder(
+    const fieldIdsWhenSannsynlig = renderFieldsToIncludeInFormInOrder(
       "FLERVALG_FRITEKST_V1",
       {
         ...defaultValues,
@@ -37,7 +37,7 @@ describe("getFieldsToIncludeInForm", () => {
       },
     ).map((field) => field.fieldId);
 
-    const fieldIdsWhenLiteSannsynlig = getFieldsToIncludeInFormInOrder(
+    const fieldIdsWhenLiteSannsynlig = renderFieldsToIncludeInFormInOrder(
       "FLERVALG_FRITEKST_V1",
       {
         ...defaultValues,
@@ -46,7 +46,7 @@ describe("getFieldsToIncludeInForm", () => {
     ).map((field) => field.fieldId);
 
     const fieldIdsWhenUsikkerAndDarligSamarbeid =
-      getFieldsToIncludeInFormInOrder("FLERVALG_FRITEKST_V1", {
+      renderFieldsToIncludeInFormInOrder("FLERVALG_FRITEKST_V1", {
         ...defaultValues,
         tilbakeTilJobbenHvorSannsynligFlervalg: "1c",
         arbeidsgiverHvordanErSamarbeidFlervalg: "2b",
@@ -79,12 +79,12 @@ describe("getFieldsToIncludeInForm", () => {
 
     const defaultValues = getFormDefaultValuesForFormVariant("FLERVALG_V2");
 
-    const fieldIdsWithDefaultValues = getFieldsToIncludeInFormInOrder(
+    const fieldIdsWithDefaultValues = renderFieldsToIncludeInFormInOrder(
       "FLERVALG_V2",
       defaultValues,
     ).map((field) => field.fieldId);
 
-    const fieldIdsWithFilledValues = getFieldsToIncludeInFormInOrder(
+    const fieldIdsWithFilledValues = renderFieldsToIncludeInFormInOrder(
       "FLERVALG_V2",
       {
         mulighetForTilbakeTilJobbenFlervalg: "utfordrende",
@@ -104,7 +104,7 @@ describe("getFieldsToIncludeInForm", () => {
       formVariant: T,
       fieldId: KartleggingsspormalFormFieldId,
     ): Record<string, string | undefined> {
-      const question = getFieldsToIncludeInFormInOrder(
+      const question = renderFieldsToIncludeInFormInOrder(
         formVariant,
         getFormDefaultValuesForFormVariant(formVariant),
       ).find((field) => field.fieldId === fieldId)?.question;

--- a/src/forms/kartleggingssporsmal/formVariants/renderFieldsToIncludeInForm.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/renderFieldsToIncludeInForm.ts
@@ -7,16 +7,16 @@ import { formVariantConfigs } from "./formVariants";
 import type { FormValuesForVariant } from "./types/FormValues";
 import type { FormVariant } from "./types/FormVariant";
 
-type RenderedFieldData = {
+type RenderedField = {
   fieldId: KartleggingsspormalFormFieldId;
-  question: Question;
   isRequired: boolean;
+  question: Question;
 };
 
 /**
- * Returns a list of FieldData for fields that should be included in the form
- * for a given form variant, given the current form values (to
- * evaluate conditionallyIncludeIf functions). The resulting list is in the
+ * Returns a list of RenderedField data for fields that should be included in
+ * the form for a given form variant, given the current form values (to
+ * evaluate conditionallyAddIf functions). The resulting list is in the
  * same order as the form fields are defined in the form variant config, which
  * is the order they should be rendered in the form and appear in the resulting
  * FormSnapshot.
@@ -24,54 +24,51 @@ type RenderedFieldData = {
 export function renderFieldsToIncludeInFormInOrder<T extends FormVariant>(
   formVariant: T,
   formValues: FormValuesForVariant<T>,
-): Array<RenderedFieldData> {
+): Array<RenderedField> {
   const fieldsConfigForVariant = formVariantConfigs[formVariant].formFields;
 
-  const filteredByConditionalFields = fieldsConfigForVariant.filter(
+  const filteredFieldsConfigForVariant = fieldsConfigForVariant.filter(
     (fieldConfig) =>
       fieldConfig.conditionallyAddIf
         ? fieldConfig.conditionallyAddIf(formValues)
         : true,
   );
 
-  const mappedToFieldData: RenderedFieldData[] =
-    filteredByConditionalFields.map(
-      ({
+  const renderedFields: RenderedField[] = filteredFieldsConfigForVariant.map(
+    ({ fieldId, isRequired, someOptionsTriggerAdditionOfFritekstField }) => {
+      const question = allKartleggingssporsmalQuestions[fieldId];
+
+      const renderedField: RenderedField = {
         fieldId,
         isRequired,
-        canTriggerAdditionOfFritekstField:
-          canTriggerAdditionOfFritekstFieldInThisVariant,
-      }) => {
-        const question = allKartleggingssporsmalQuestions[fieldId];
+        question: applyFritekstTriggerDescriptionsToQuestion(
+          question,
+          someOptionsTriggerAdditionOfFritekstField || false,
+        ),
+      };
 
-        return {
-          fieldId,
-          isRequired,
-          question: applyFritekstTriggerDescriptionsToQuestion(
-            question,
-            canTriggerAdditionOfFritekstFieldInThisVariant || false,
-          ),
-        };
-      },
-    );
+      return renderedField;
+    },
+  );
 
-  return mappedToFieldData;
+  return renderedFields;
 }
 
 /**
  * For radio group questions where selecting an option can trigger the
  * addition of a fritekst field, appends each option's
- * descriptionWhenOptionTriggersAdditionOfTextField to its description so
- * users are told upfront that elaborating is possible. Left unchanged for
- * other question types or when the trigger flag is not set for this variant.
+ * descriptionWhenOptionTriggersAdditionOfTextFieldInVariant to its description,
+ * typically to tell users upfront that elaborating is possible. The question is
+ * left unchanged for other question types or when the trigger flag is not set
+ * for this variant.
  */
 function applyFritekstTriggerDescriptionsToQuestion(
   question: Question,
-  canTriggerAdditionOfFritekstFieldInThisVariant: boolean,
+  someOptionsTriggerAdditionOfFritekstFieldInVariant: boolean,
 ): Question {
   if (
     question.type !== "RADIO_GROUP" ||
-    !canTriggerAdditionOfFritekstFieldInThisVariant
+    !someOptionsTriggerAdditionOfFritekstFieldInVariant
   ) {
     return question;
   }
@@ -84,7 +81,7 @@ function applyFritekstTriggerDescriptionsToQuestion(
       description:
         [
           option.description,
-          option.descriptionWhenOptionTriggersAdditionOfTextField,
+          option.descriptionWhenOptionTriggersAdditionOfTextFieldInVariant,
         ]
           .filter(Boolean)
           .join(" ") || undefined,

--- a/src/forms/kartleggingssporsmal/formVariants/renderFieldsToIncludeInForm.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/renderFieldsToIncludeInForm.ts
@@ -21,7 +21,7 @@ type RenderedFieldData = {
  * is the order they should be rendered in the form and appear in the resulting
  * FormSnapshot.
  */
-export function getFieldsToIncludeInFormInOrder<T extends FormVariant>(
+export function renderFieldsToIncludeInFormInOrder<T extends FormVariant>(
   formVariant: T,
   formValues: FormValuesForVariant<T>,
 ): Array<RenderedFieldData> {
@@ -29,8 +29,8 @@ export function getFieldsToIncludeInFormInOrder<T extends FormVariant>(
 
   const filteredByConditionalFields = fieldsConfigForVariant.filter(
     (fieldConfig) =>
-      fieldConfig.conditionallyIncludeIf
-        ? fieldConfig.conditionallyIncludeIf(formValues)
+      fieldConfig.conditionallyAddIf
+        ? fieldConfig.conditionallyAddIf(formValues)
         : true,
   );
 

--- a/src/forms/kartleggingssporsmal/formVariants/types/FormVariantConfig.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/types/FormVariantConfig.ts
@@ -44,7 +44,7 @@ export type FormVariantConfig<
      * from the live visible form based on form values of other fields, and
      * whether it should be added in the resulting FormSnapshot.
      */
-    conditionallyIncludeIf?: (
+    conditionallyAddIf?: (
       // Cannot use FormValuesForVariant<T> here — that type depends on
       // formVariantConfigs, which depends on FormVariantConfig, which would
       // give a circular reference.

--- a/src/forms/kartleggingssporsmal/formVariants/types/FormVariantConfig.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/types/FormVariantConfig.ts
@@ -27,15 +27,22 @@ export type FormVariantConfig<
      */
     isRequired: boolean;
     /**
-     * Indicates whether descriptions on individual radio options should be
-     * shown. This is used when an option description refers to a follow-up
-     * text field that is only present in some variants.
+     * Set to true if this is a radio group question and selecting some of the
+     * options will trigger a conditionally included fritekst field in this
+     * form variant.
+     * Used to determine if a dedicated description should be shown for any
+     * such option. This flag allows the same radio group question to be reused
+     * in various form variants, where selecting certain options can trigger
+     * the addition of a text field in one variant and not in the other.
+     *
+     * @see descriptionWhenOptionTriggersAdditionOfTextField on RadioOption in
+     * RadioGroup.
      */
-    showOptionDescriptions?: boolean;
+    canTriggerAdditionOfFritekstField?: boolean;
     /**
      * Optional function to determine if the field should be added to or removed
      * from the live visible form based on form values of other fields, and
-     * whether it should be included in the resulting FormSnapshot.
+     * whether it should be added in the resulting FormSnapshot.
      */
     conditionallyIncludeIf?: (
       // Cannot use FormValuesForVariant<T> here — that type depends on

--- a/src/forms/kartleggingssporsmal/formVariants/types/FormVariantConfig.ts
+++ b/src/forms/kartleggingssporsmal/formVariants/types/FormVariantConfig.ts
@@ -35,10 +35,10 @@ export type FormVariantConfig<
      * in various form variants, where selecting certain options can trigger
      * the addition of a text field in one variant and not in the other.
      *
-     * @see descriptionWhenOptionTriggersAdditionOfTextField on RadioOption in
-     * RadioGroup.
+     * @see descriptionWhenOptionTriggersAdditionOfTextFieldInVariant on
+     * RadioOption in RadioGroup.
      */
-    canTriggerAdditionOfFritekstField?: boolean;
+    someOptionsTriggerAdditionOfFritekstField?: boolean;
     /**
      * Optional function to determine if the field should be added to or removed
      * from the live visible form based on form values of other fields, and

--- a/src/forms/kartleggingssporsmal/questions/radioGroupQuestions.ts
+++ b/src/forms/kartleggingssporsmal/questions/radioGroupQuestions.ts
@@ -28,7 +28,7 @@ export const radioGroupQuestions = {
         id: "utfordrende",
         label:
           "Jeg ser på det som utfordrende å komme tilbake til samme jobb og stilling",
-        descriptionWhenOptionTriggersAdditionOfTextField:
+        descriptionWhenOptionTriggersAdditionOfTextFieldInVariant:
           "Du får mulighet til å utdype mer",
       },
     ],
@@ -58,7 +58,7 @@ export const radioGroupQuestions = {
         id: "nei",
         label:
           "Nei, jeg opplever manglende oppfølging og at tilpasninger er vanskelig.",
-        descriptionWhenOptionTriggersAdditionOfTextField:
+        descriptionWhenOptionTriggersAdditionOfTextFieldInVariant:
           "Du får mulighet til å utdype mer",
       },
     ],

--- a/src/forms/kartleggingssporsmal/questions/radioGroupQuestions.ts
+++ b/src/forms/kartleggingssporsmal/questions/radioGroupQuestions.ts
@@ -28,7 +28,8 @@ export const radioGroupQuestions = {
         id: "utfordrende",
         label:
           "Jeg ser på det som utfordrende å komme tilbake til samme jobb og stilling",
-        description: "Du får mulighet til å utdype mer",
+        descriptionWhenOptionTriggersAdditionOfTextField:
+          "Du får mulighet til å utdype mer",
       },
     ],
   },
@@ -57,7 +58,8 @@ export const radioGroupQuestions = {
         id: "nei",
         label:
           "Nei, jeg opplever manglende oppfølging og at tilpasninger er vanskelig.",
-        description: "Du får mulighet til å utdype mer",
+        descriptionWhenOptionTriggersAdditionOfTextField:
+          "Du får mulighet til å utdype mer",
       },
     ],
   },

--- a/src/utils/kartleggingssporsmalFormSnapshot.ts
+++ b/src/utils/kartleggingssporsmalFormSnapshot.ts
@@ -1,4 +1,4 @@
-import { getFieldsToIncludeInFormInOrder } from "@/forms/kartleggingssporsmal/formVariants/getFieldsToIncludeInForm";
+import { renderFieldsToIncludeInFormInOrder } from "@/forms/kartleggingssporsmal/formVariants/renderFieldsToIncludeInForm";
 import type { FormValuesForVariant } from "@/forms/kartleggingssporsmal/formVariants/types/FormValues";
 import type { FormVariant } from "@/forms/kartleggingssporsmal/formVariants/types/FormVariant";
 import type {
@@ -19,7 +19,7 @@ function mapFormValuesToFieldSnapshots<T extends FormVariant>(
   formValues: FormValuesForVariant<T>,
 ): FieldSnapshot[] {
   const fields: FieldSnapshot[] = [];
-  const fieldsToInclude = getFieldsToIncludeInFormInOrder(
+  const fieldsToInclude = renderFieldsToIncludeInFormInOrder(
     formVariant,
     formValues,
   );


### PR DESCRIPTION
## Beskrivelse

Mer semantisk konfigurasjon for å til at visse valg for visse spørsmål har en bestemt beskrivelse når spørsmålet brukes i en variant der det å velge valget trigger at det legges til et fritekst spørsmål.

Der flervalg spørsmålet konfigureres spesifiserer man på valget teksten `descriptionWhenOptionTriggersAdditionOfTextFieldInVariant` (feks "Du får mulighet til å utdype mer"), og i variant konfigurasjonen setter man `someOptionsTriggerAdditionOfFritekstField` på feltet til true.

Og litt renaming for mer tydelig kode.